### PR TITLE
feature/piggy-banks-home

### DIFF
--- a/src/components/Screens/HomeScreen.tsx
+++ b/src/components/Screens/HomeScreen.tsx
@@ -315,6 +315,81 @@ function Bills() {
   );
 }
 
+function PiggyBanks() {
+  const { colors } = useThemeColors();
+  const piggyBanks = useSelector((state: RootState) => state.piggybank.piggyBanks);
+  const loading = useSelector((state: RootState) => state.loading.effects.piggybanks?.getPiggyBanks?.loading);
+  const dispatch = useDispatch<RootDispatch>();
+
+  return (
+    <AScrollView
+      showsVerticalScrollIndicator={false}
+      refreshControl={(
+        <RefreshControl
+          refreshing={false}
+          onRefresh={() => dispatch.piggybank.getPiggyBanks()}
+        />
+      )}
+    >
+      <AText fontSize={25} lineHeight={27} style={{ margin: 15 }}>
+        {translate('home_piggy_banks')}
+      </AText>
+      {piggyBanks.map((pb) => (
+        <AStack
+          key={pb.id}
+          mx={15}
+          style={{
+            height: 60,
+          }}
+        >
+          <AStackFlex row justifyContent="space-between">
+            <AStack
+              style={{ maxWidth: '80%' }}
+              alignItems="flex-start"
+            >
+              <AText fontSize={14} lineHeight={22} numberOfLines={1}>
+                {pb.attributes.name}
+              </AText>
+              <AText fontSize={12} lineHeight={20} numberOfLines={1}>
+                {localNumberFormat(pb.attributes.currencyCode, pb.attributes.currentAmount)}
+                {' / '}
+                {localNumberFormat(pb.attributes.currencyCode, pb.attributes.targetAmount)}
+              </AText>
+            </AStack>
+
+            <ASkeleton loading={loading}>
+              <AStack alignItems="flex-end">
+                <AStack
+                  px={6}
+                  py={2}
+                  backgroundColor={pb.attributes.leftToSave > 0.0 ? colors.brandNeutralLight : colors.brandSuccessLight}
+                  style={{ borderRadius: 5 }}
+                >
+                  <AText
+                    fontSize={15}
+                    numberOfLines={1}
+                    color={pb.attributes.leftToSave > 0.0 ? colors.brandNeutral : colors.brandSuccess}
+                    style={{ textAlign: 'center' }}
+                    bold
+                  >
+                    {`${pb.attributes.percentage.toFixed(0)}%`}
+                  </AText>
+                </AStack>
+              </AStack>
+            </ASkeleton>
+          </AStackFlex>
+
+          <AProgressBar
+            color={pb.attributes.percentage > 50.0 ? colors.green : colors.brandWarning}
+            value={pb.attributes.percentage}
+          />
+        </AStack>
+      ))}
+      <AView style={{ height: 150 }} />
+    </AScrollView>
+  );
+}
+
 function NetWorth() {
   const { colors } = useThemeColors();
   const hideBalance = useSelector((state: RootState) => state.configuration.hideBalance);
@@ -410,6 +485,7 @@ export default function HomeScreen() {
     <Ionicons key="pricetag" name="pricetags" size={22} color={colors.text} />,
     <MaterialCommunityIcons key="progress-check" name="progress-check" size={22} color={colors.text} />,
     <Ionicons key="calendar-clear" name="calendar-clear" size={22} color={colors.text} />,
+    <MaterialCommunityIcons key="piggy-bank" name="piggy-bank" size={22} color={colors.text} />,
   ];
 
   useEffect(() => {
@@ -438,6 +514,7 @@ export default function HomeScreen() {
           dispatch.categories.getInsightCategories();
           dispatch.budgets.getInsightBudgets();
           dispatch.bills.getBills();
+          dispatch.piggybank.getPiggyBanks();
         }
       };
 
@@ -511,6 +588,7 @@ export default function HomeScreen() {
             <InsightCategories key="2" />
             <InsightBudgets key="3" />
             <Bills key="4" />
+            <PiggyBanks key="5" />
           </AnimatedPagerView>
         </AView>
       </View>

--- a/src/i18n/locale/translations/en-US.ts
+++ b/src/i18n/locale/translations/en-US.ts
@@ -145,6 +145,7 @@ export default {
 
   // from X.X.X
   home_bills: 'Bills',
+  home_piggy_banks: 'Piggy Banks',
   bills_paid: 'Paid',
   bills_not_expected: 'Not expected',
   transaction_form_bill_label: 'Bill',

--- a/src/models/configuration.ts
+++ b/src/models/configuration.ts
@@ -207,6 +207,7 @@ export default createModel<RootModel>()({
         dispatch.currencies.resetState(),
         dispatch.firefly.resetState(),
         dispatch.transactions.resetState(),
+        dispatch.piggyBanks.resetState()
       ]);
     },
   }),

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -7,10 +7,12 @@ import configuration from './configuration';
 import currencies from './currencies';
 import firefly from './firefly';
 import transactions from './transactions';
+import piggybank from './piggybank';
 
 export interface RootModel extends Models<RootModel> {
   accounts: typeof accounts
   bills: typeof bills
+  piggybank : typeof piggybank
   budgets: typeof budgets
   categories: typeof categories
   configuration: typeof configuration
@@ -22,6 +24,7 @@ export interface RootModel extends Models<RootModel> {
 export const models: RootModel = {
   accounts,
   bills,
+  piggybank,
   budgets,
   categories,
   configuration,

--- a/src/models/piggybank.ts
+++ b/src/models/piggybank.ts
@@ -1,0 +1,53 @@
+import { createModel } from '@rematch/core';
+import { RootModel } from './index';
+
+/*
+ * Piggy bank model created following the API documentation from the Firefly III docs.
+ * Currently this is a subset of all available properties. Additional properties may be added as needed.
+ * {@link https://api-docs.firefly-iii.org/#/piggy_banks/listPiggyBank|Piggy Bank API}
+ */
+export type PiggyBank = {
+    id : string,
+    type: string,
+    attributes: {
+        createdAt: string,
+        updatedAt: string,
+        accountId: string,
+        accountName: string,
+        name: string,
+        currencyId: string,
+        currencyCode: string,
+        currencySymbol: string,
+        targetAmount: number,
+        percentage: number,
+        currentAmount: number,
+        leftToSave: number,
+        savePerMonth: number,
+    }
+}
+
+type PiggyBankState = {
+    piggyBanks : PiggyBank[]
+}
+
+const INITIAL_STATE : PiggyBankState = { piggyBanks: [] };
+
+export default createModel<RootModel>()({
+  state: INITIAL_STATE,
+  reducers: {
+    setPiggyBanks(state, payload): PiggyBankState {
+      return { ...state, piggyBanks: payload.piggyBanks };
+    },
+
+    resetState() {
+      return INITIAL_STATE;
+    },
+  },
+
+  effects: (dispatch) => ({
+    async getPiggyBanks(_ : void): Promise<void> {
+      const { data: piggyBanks } = await dispatch.configuration.apiFetch({ url: '/api/v1/piggy-banks' }) as {data : PiggyBank[]};
+      dispatch.piggybank.setPiggyBanks({ piggyBanks });
+    },
+  }),
+});


### PR DESCRIPTION
**Summary**
- Added piggy bank home screen tab (used Material Community piggy bank icon) and page. The page was designed to be similar to the budgets page.
- Created piggy bank model based on Firefly III's documentation [Piggy Bank API](https://api-docs.firefly-iii.org/#/piggy_banks/listPiggyBank)
- Added `home_piggy_banks` to en-US localization text.
<img src="https://github.com/victorbalssa/abacus/assets/19892982/5ec0410b-238c-44c4-a14d-1d0a7a633c08" width="250"/>
<img src="https://github.com/victorbalssa/abacus/assets/19892982/e776825d-ec73-4c19-b029-51a9c1d7b946" width="250"/>


