### PR TITLE
Added new selectable gradient + accent colors

### DIFF
--- a/src/components/Forms/OauthForm.tsx
+++ b/src/components/Forms/OauthForm.tsx
@@ -42,6 +42,7 @@ export default function OauthForm({
   const loading = useSelector((state: RootState) => state.loading.effects.firefly.getNewAccessToken?.loading);
   const [isOauth, setIsAuth] = useState<boolean>(true);
   const toggleIsOauth = () => setIsAuth((value) => !value);
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle || colors.brandStyleOrange);
   const isMinimumRequirement = () => {
     if (isOauth && config.oauthClientId) {
       return true;
@@ -110,7 +111,7 @@ export default function OauthForm({
 
           <AStackFlex row py={10} alignItems="center" justifyContent="space-between">
             <AText fontSize={12}>{translate('auth_use_personal_access_token')}</AText>
-            <Switch testID="toggle_is_oauth" thumbColor="white" trackColor={{ false: '#767577', true: colors.brandStyle }} onValueChange={() => toggleIsOauth()} value={!isOauth} />
+            <Switch testID="toggle_is_oauth" thumbColor="white" trackColor={{ false: '#767577', true: selectedBrandStyle }} onValueChange={() => toggleIsOauth()} value={!isOauth} />
           </AStackFlex>
 
           {isOauth && (
@@ -136,7 +137,7 @@ export default function OauthForm({
                   flexDirection: 'row',
                   justifyContent: 'center',
                   alignItems: 'center',
-                  backgroundColor: colors.brandStyle,
+                  backgroundColor: selectedBrandStyle,
                   borderRadius: 10,
                   marginLeft: 10,
                   paddingRight: 7,

--- a/src/components/Screens/ColorSelectionScreen.tsx
+++ b/src/components/Screens/ColorSelectionScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, FlatList, TouchableOpacity, StyleSheet, Dimensions } from 'react-native';
+import { View, TouchableOpacity, StyleSheet, Dimensions } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -8,37 +8,39 @@ import { useThemeColors } from '../../lib/common';
 import colors from '../../constants/colors';
 
 const themes = [
-  'gradientPeach',
-  'gradientGold',
-  'gradientOrange',
-  'gradientYellow',
-  'gradientMint',
-  'gradientTeal',
-  'gradientGreen',
-  'gradientCyan',
-  'gradientLavender',
-  'gradientPurple',
-  'gradientPink',
   'gradientRed',
-  'gradientBrown',
+  'gradientOrange',
+  'gradientLightOrange',
+  'gradientGold',
+  'gradientYellow',
+  'gradientLightYellow',
+  'gradientDarkGreen',
+  'gradientGreen',
+  'gradientMint',
   'gradientBlue',
+  'gradientTeal',
+  'gradientCyan',
+  'gradientPurple',
+  'gradientLavender',
+  'gradientPink',
 ];
 
 const themeToBrandStyle = {
-  gradientPeach: colors.brandStylePeach,
-  gradientGold: colors.brandStyleGold,
-  gradientOrange: colors.brandStyleOrange,
-  gradientYellow: colors.brandStyleYellow,
-  gradientMint: colors.brandStyleMint,
-  gradientTeal: colors.brandStyleTeal,
-  gradientGreen: colors.brandStyleGreen,
-  gradientCyan: colors.brandStyleCyan,
-  gradientLavender: colors.brandStyleLavender,
-  gradientPurple: colors.brandStylePurple,
-  gradientPink: colors.brandStylePink,
   gradientRed: colors.brandStyleRed,
-  gradientBrown: colors.brandStyleBrown,
+  gradientOrange: colors.brandStyleOrange,
+  gradientLightOrange: colors.brandStyleLightOrange,
+  gradientGold: colors.brandStyleGold,
+  gradientYellow: colors.brandStyleYellow,
+  gradientLightYellow: colors.brandStyleLightYellow,
+  gradientDarkGreen: colors.brandStyleDarkGreen,
+  gradientGreen: colors.brandStyleGreen,
+  gradientMint: colors.brandStyleMint,
   gradientBlue: colors.brandStyleBlue,
+  gradientTeal: colors.brandStyleTeal,
+  gradientCyan: colors.brandStyleCyan,
+  gradientPurple: colors.brandStylePurple,
+  gradientLavender: colors.brandStyleLavender,
+  gradientPink: colors.brandStylePink,
 };
 
 const { width } = Dimensions.get('window');
@@ -46,9 +48,11 @@ const numColumns = 3;
 const tileSize = (width - (numColumns + 1) * 10) / numColumns;
 
 const styles = StyleSheet.create({
-  grid: {
-    paddingHorizontal: 5,
-    justifyContent: 'center',
+  container: {
+    flex: 1,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-around',
   },
   colorTile: {
     width: tileSize,
@@ -65,10 +69,8 @@ const styles = StyleSheet.create({
 });
 
 export default function ColorSelectionScreen() {
-  const { colors: themeColors } = useThemeColors();
   const currentTheme = useSelector((state: RootState) => state.configuration.selectedTheme || 'gradientOrange');
   const dispatch = useDispatch<RootDispatch>();
-  const insets = useSafeAreaInsets();
   const navigation = useNavigation();
 
   const handleColorSelect = (theme: string) => {
@@ -79,23 +81,18 @@ export default function ColorSelectionScreen() {
   };
 
   return (
-    <View style={{ flex: 1, backgroundColor: themeColors.backgroundColor, paddingTop: insets.top }}>
-      <FlatList
-        data={themes}
-        renderItem={({ item }) => (
-          <TouchableOpacity
-            style={[
-              styles.colorTile,
-              { backgroundColor: themeToBrandStyle[item] },
-              currentTheme === item && styles.selectedTile,
-            ]}
-            onPress={() => handleColorSelect(item)}
-          />
-        )}
-        keyExtractor={(item) => item}
-        numColumns={numColumns}
-        contentContainerStyle={styles.grid}
-      />
+    <View style={{ flex: 1, flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'space-around' }}>
+      {themes.map((theme) => (
+        <TouchableOpacity
+          key={theme}
+          style={[
+            styles.colorTile,
+            { backgroundColor: themeToBrandStyle[theme] },
+            currentTheme === theme && styles.selectedTile,
+          ]}
+          onPress={() => handleColorSelect(theme)}
+        />
+      ))}
     </View>
   );
 }

--- a/src/components/Screens/ColorSelectionScreen.tsx
+++ b/src/components/Screens/ColorSelectionScreen.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { View, FlatList, TouchableOpacity, StyleSheet, Dimensions } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigation } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { RootDispatch, RootState } from '../../store';
+import { useThemeColors } from '../../lib/common';
+import colors from '../../constants/colors';
+
+const themes = [
+  'gradientPeach',
+  'gradientGold',
+  'gradientOrange',
+  'gradientYellow',
+  'gradientMint',
+  'gradientTeal',
+  'gradientGreen',
+  'gradientCyan',
+  'gradientLavender',
+  'gradientPurple',
+  'gradientPink',
+  'gradientRed',
+  'gradientBrown',
+  'gradientBlue',
+];
+
+const themeToBrandStyle = {
+  gradientPeach: colors.brandStylePeach,
+  gradientGold: colors.brandStyleGold,
+  gradientOrange: colors.brandStyleOrange,
+  gradientYellow: colors.brandStyleYellow,
+  gradientMint: colors.brandStyleMint,
+  gradientTeal: colors.brandStyleTeal,
+  gradientGreen: colors.brandStyleGreen,
+  gradientCyan: colors.brandStyleCyan,
+  gradientLavender: colors.brandStyleLavender,
+  gradientPurple: colors.brandStylePurple,
+  gradientPink: colors.brandStylePink,
+  gradientRed: colors.brandStyleRed,
+  gradientBrown: colors.brandStyleBrown,
+  gradientBlue: colors.brandStyleBlue,
+};
+
+const { width } = Dimensions.get('window');
+const numColumns = 3;
+const tileSize = (width - (numColumns + 1) * 10) / numColumns;
+
+const styles = StyleSheet.create({
+  grid: {
+    paddingHorizontal: 5,
+    justifyContent: 'center',
+  },
+  colorTile: {
+    width: tileSize,
+    height: tileSize,
+    margin: 5,
+    borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  selectedTile: {
+    borderWidth: 2,
+    borderColor: 'black',
+  },
+});
+
+export default function ColorSelectionScreen() {
+  const { colors: themeColors } = useThemeColors();
+  const currentTheme = useSelector((state: RootState) => state.configuration.selectedTheme);
+  const dispatch = useDispatch<RootDispatch>();
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation();
+
+  const handleColorSelect = (theme: string) => {
+    const selectedBrandStyle = themeToBrandStyle[theme];
+    dispatch.configuration.setSelectedTheme(theme);
+    dispatch.configuration.setSelectedBrandStyle(selectedBrandStyle);
+    navigation.goBack();
+  };
+
+  return (
+    <View style={{ flex: 1, backgroundColor: themeColors.backgroundColor, paddingTop: insets.top }}>
+      <FlatList
+        data={themes}
+        renderItem={({ item }) => (
+          <TouchableOpacity
+            style={[
+              styles.colorTile,
+              { backgroundColor: themeToBrandStyle[item] },
+              currentTheme === item && styles.selectedTile,
+            ]}
+            onPress={() => handleColorSelect(item)}
+          />
+        )}
+        keyExtractor={(item) => item}
+        numColumns={numColumns}
+        contentContainerStyle={styles.grid}
+      />
+    </View>
+  );
+}

--- a/src/components/Screens/ColorSelectionScreen.tsx
+++ b/src/components/Screens/ColorSelectionScreen.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { View, TouchableOpacity, StyleSheet, Dimensions } from 'react-native';
+import { View, TouchableOpacity, StyleSheet, Dimensions, useColorScheme } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { RootDispatch, RootState } from '../../store';
-import { useThemeColors } from '../../lib/common';
 import colors from '../../constants/colors';
 
 const themes = [
@@ -53,6 +51,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     justifyContent: 'space-around',
+    alignItems: 'center',
   },
   colorTile: {
     width: tileSize,
@@ -64,7 +63,10 @@ const styles = StyleSheet.create({
   },
   selectedTile: {
     borderWidth: 2,
-    borderColor: 'black',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.8,
+    shadowRadius: 3,
+    elevation: 5,
   },
 });
 
@@ -72,6 +74,8 @@ export default function ColorSelectionScreen() {
   const currentTheme = useSelector((state: RootState) => state.configuration.selectedTheme || 'gradientOrange');
   const dispatch = useDispatch<RootDispatch>();
   const navigation = useNavigation();
+  const colorScheme = useColorScheme();
+  const highlightColor = colorScheme === 'dark' ? 'white' : 'black';
 
   const handleColorSelect = (theme: string) => {
     const selectedBrandStyle = themeToBrandStyle[theme];
@@ -81,14 +85,14 @@ export default function ColorSelectionScreen() {
   };
 
   return (
-    <View style={{ flex: 1, flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'space-around' }}>
+    <View style={styles.container}>
       {themes.map((theme) => (
         <TouchableOpacity
           key={theme}
           style={[
             styles.colorTile,
             { backgroundColor: themeToBrandStyle[theme] },
-            currentTheme === theme && styles.selectedTile,
+            currentTheme === theme && [styles.selectedTile, { borderColor: highlightColor, shadowColor: highlightColor }],
           ]}
           onPress={() => handleColorSelect(theme)}
         />

--- a/src/components/Screens/ColorSelectionScreen.tsx
+++ b/src/components/Screens/ColorSelectionScreen.tsx
@@ -66,7 +66,7 @@ const styles = StyleSheet.create({
 
 export default function ColorSelectionScreen() {
   const { colors: themeColors } = useThemeColors();
-  const currentTheme = useSelector((state: RootState) => state.configuration.selectedTheme);
+  const currentTheme = useSelector((state: RootState) => state.configuration.selectedTheme || 'gradientOrange');
   const dispatch = useDispatch<RootDispatch>();
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();

--- a/src/components/Screens/ConfigurationScreen.tsx
+++ b/src/components/Screens/ConfigurationScreen.tsx
@@ -37,6 +37,7 @@ export default function ConfigurationScreen({ navigation }: ScreenType) {
   const backendURL = useSelector((state: RootState) => state.configuration.backendURL);
   const useBiometricAuth = useSelector((state: RootState) => state.configuration.useBiometricAuth);
   const dispatch = useDispatch<RootDispatch>();
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
   const {
     configuration: {
       setUseBiometricAuth,
@@ -187,7 +188,7 @@ export default function ConfigurationScreen({ navigation }: ScreenType) {
           }}
         >
           <AText fontSize={14}>{translate('auth_form_biometrics_lock')}</AText>
-          <Switch thumbColor="white" trackColor={{ false: '#767577', true: colors.brandStyle }} onValueChange={() => bioAuthCallback(setUseBiometricAuth)} value={useBiometricAuth} />
+          <Switch thumbColor="white" trackColor={{ false: '#767577', true: selectedBrandStyle }} onValueChange={() => bioAuthCallback(setUseBiometricAuth)} value={useBiometricAuth} />
         </AStack>
       </AView>
 
@@ -302,8 +303,37 @@ export default function ConfigurationScreen({ navigation }: ScreenType) {
           }}
         >
           <AText fontSize={14}>{translate('close_after_transaction')}</AText>
-          <Switch thumbColor="white" trackColor={{ false: '#767577', true: colors.brandStyle }} onValueChange={handleCheckBoxChange} value={closeTransactionScreen} />
+          <Switch thumbColor="white" trackColor={{ false: '#767577', true: selectedBrandStyle }} onValueChange={handleCheckBoxChange} value={closeTransactionScreen} />
         </AStack>
+      </AView>
+
+      <AText py={10} px={10} fontSize={18} bold>
+        {translate('configuration_theme')}
+      </AText>
+      <AView
+        style={{
+          borderTopWidth: 0.5,
+          borderBottomWidth: 0.5,
+          borderColor: colors.listBorderColor,
+          backgroundColor: colors.tileBackgroundColor,
+        }}
+      >
+        <APressable
+          flexDirection="row"
+          onPress={() => navigation.navigate('ColorSelectionScreen', { filterType: '', selectFilter: () => {} })}
+          style={{
+            justifyContent: 'space-between',
+            height: 45,
+            paddingHorizontal: 10,
+            paddingVertical: 5,
+            marginLeft: 10,
+            borderBottomWidth: 0.5,
+            borderColor: colors.listBorderColor,
+          }}
+        >
+          <AText fontSize={14}>{translate('configuration_theme_selection')}</AText>
+          <FontAwesome name="angle-right" size={22} color="gray" />
+        </APressable>
       </AView>
 
       <AText py={10} px={10} fontSize={18} bold>

--- a/src/components/Screens/ConfigurationScreen.tsx
+++ b/src/components/Screens/ConfigurationScreen.tsx
@@ -37,7 +37,7 @@ export default function ConfigurationScreen({ navigation }: ScreenType) {
   const backendURL = useSelector((state: RootState) => state.configuration.backendURL);
   const useBiometricAuth = useSelector((state: RootState) => state.configuration.useBiometricAuth);
   const dispatch = useDispatch<RootDispatch>();
-  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle || colors.brandStyleOrange);
   const {
     configuration: {
       setUseBiometricAuth,

--- a/src/components/Screens/FilterScreen.tsx
+++ b/src/components/Screens/FilterScreen.tsx
@@ -13,7 +13,7 @@ import translate from '../../i18n/locale';
 
 export default function FilterScreen({ navigation, route }: ScreenType) {
   const { colors } = useThemeColors();
-  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle || colors.brandStyleOrange);
   const {
     filterType,
     selectFilter,

--- a/src/components/Screens/FilterScreen.tsx
+++ b/src/components/Screens/FilterScreen.tsx
@@ -10,8 +10,10 @@ import { useThemeColors } from '../../lib/common';
 import { ScreenType } from '../../types/screen';
 import { types } from '../../models/transactions';
 import translate from '../../i18n/locale';
+
 export default function FilterScreen({ navigation, route }: ScreenType) {
   const { colors } = useThemeColors();
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
   const {
     filterType,
     selectFilter,
@@ -96,7 +98,7 @@ export default function FilterScreen({ navigation, route }: ScreenType) {
             }}
           >
             <View style={{
-              backgroundColor: selectedAccountIds?.includes(parseInt(account.id, 10)) ? colors.brandStyle : colors.filterBorderColor,
+              backgroundColor: selectedAccountIds?.includes(parseInt(account.id, 10)) ? selectedBrandStyle : colors.filterBorderColor,
               justifyContent: 'center',
               alignItems: 'center',
               borderRadius: 10,

--- a/src/components/Screens/HomeScreen.tsx
+++ b/src/components/Screens/HomeScreen.tsx
@@ -101,26 +101,26 @@ function AssetsAccounts() {
           <Switch style={{ marginHorizontal: 10 }} thumbColor="white" trackColor={{ false: '#767577', true: colors.brandStyle }} onValueChange={onSwitch} value={displayAllAccounts} />
         </AStack>
         <AStack px={5} row justifyContent="space-between">
-        <View style={{ flex: 1, alignItems: 'flex-start', paddingLeft: '5%'  }}>
-          <TouchableOpacity onPress={() => handleSortPress('left')}>
-            <MaterialCommunityIcons
-              name="sort"
-              size={22}
-              color={lastPressed === 'left' ? colors.primary : colors.text}
-            />
-          </TouchableOpacity>
-        </View>
-        <View style={{ flex: 1, alignItems: 'flex-end', paddingRight: '5%' }}>
-          <TouchableOpacity onPress={() => handleSortPress('right')}>
-            <MaterialCommunityIcons
-              name="sort"
-              size={22}
-              color={lastPressed === 'right' ? colors.primary : colors.text}
-              style={{ transform: [{ scaleX: -1 }] }}
-            />
-          </TouchableOpacity>
-        </View>
-      </AStack>
+          <View style={{ flex: 1, alignItems: 'flex-start', paddingLeft: '5%' }}>
+            <TouchableOpacity onPress={() => handleSortPress('left')}>
+              <MaterialCommunityIcons
+                name="sort"
+                size={22}
+                color={lastPressed === 'left' ? colors.primary : colors.text}
+              />
+            </TouchableOpacity>
+          </View>
+          <View style={{ flex: 1, alignItems: 'flex-end', paddingRight: '5%' }}>
+            <TouchableOpacity onPress={() => handleSortPress('right')}>
+              <MaterialCommunityIcons
+                name="sort"
+                size={22}
+                color={lastPressed === 'right' ? colors.primary : colors.text}
+                style={{ transform: [{ scaleX: -1 }] }}
+              />
+            </TouchableOpacity>
+          </View>
+        </AStack>
         {sortedAccounts.map((account, index) => (
           <AStack
             key={account.id}
@@ -463,43 +463,43 @@ function NetWorth() {
     <View testID="home_screen_net_worth">
       <Pressable onPress={() => dispatch.configuration.setHideBalance(!hideBalance)}>
         {!hideBalance && (
-        <AView style={{
-          height: 90,
-          width: 300,
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-        >
-          <AText fontSize={12} lineHeight={18}>
-            {`${translate('home_net_worth')} • ${currentCode}`}
-          </AText>
-          <ASkeleton loading={loading}>
-            <AText fontSize={35} lineHeight={37} bold>
-              {localNumberFormat(currentCode, parseFloat(netWorth[0]?.monetaryValue || '0'))}
+          <AView style={{
+            height: 90,
+            width: 300,
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+          >
+            <AText fontSize={12} lineHeight={18}>
+              {`${translate('home_net_worth')} • ${currentCode}`}
             </AText>
-          </ASkeleton>
-
-          {balance && balance[0] && earned && earned[0] && spent && spent[0] && !hideBalance && (
-          <ASkeleton loading={loading}>
-            <AStack
-              py={0}
-              my={1}
-              px={5}
-              backgroundColor={parseFloat(balance[0].monetaryValue) < 0 ? colors.brandNeutralLight : colors.brandSuccessLight}
-              style={{ borderRadius: 5 }}
-            >
-              <AText
-                py={0}
-                bold
-                fontSize={12}
-                color={parseFloat(balance[0].monetaryValue) < 0 ? colors.brandNeutral : colors.brandSuccess}
-              >
-                {`${parseFloat(balance[0].monetaryValue) > 0 ? '+' : ''}${localNumberFormat(balance[0].currencyCode, parseFloat(balance[0].monetaryValue))}`}
+            <ASkeleton loading={loading}>
+              <AText fontSize={35} lineHeight={37} bold>
+                {localNumberFormat(currentCode, parseFloat(netWorth[0]?.monetaryValue || '0'))}
               </AText>
-            </AStack>
-          </ASkeleton>
-          )}
-        </AView>
+            </ASkeleton>
+
+            {balance && balance[0] && earned && earned[0] && spent && spent[0] && !hideBalance && (
+              <ASkeleton loading={loading}>
+                <AStack
+                  py={0}
+                  my={1}
+                  px={5}
+                  backgroundColor={parseFloat(balance[0].monetaryValue) < 0 ? colors.brandNeutralLight : colors.brandSuccessLight}
+                  style={{ borderRadius: 5 }}
+                >
+                  <AText
+                    py={0}
+                    bold
+                    fontSize={12}
+                    color={parseFloat(balance[0].monetaryValue) < 0 ? colors.brandNeutral : colors.brandSuccess}
+                  >
+                    {`${parseFloat(balance[0].monetaryValue) > 0 ? '+' : ''}${localNumberFormat(balance[0].currencyCode, parseFloat(balance[0].monetaryValue))}`}
+                  </AText>
+                </AStack>
+              </ASkeleton>
+            )}
+          </AView>
         )}
 
         {hideBalance && (
@@ -593,7 +593,7 @@ export default function HomeScreen() {
   return (useMemo(() => (
     <AView style={{ flex: 1 }}>
       <LinearGradient
-        colors={colorScheme === 'light' ? ['rgb(255,211,195)', 'rgb(255,194,183)', 'rgb(248,199,193)', 'rgb(255,228,194)'] : ['#790277', '#d30847', '#FF5533', '#efe96d']}
+        colors={colorScheme === 'light' ? ['gradientOrangeLight1', 'gradientOrangeLight2', 'gradientOrangeLight3', 'gradientOrangeLight4'] : ['gradientOrangeDark1', 'gradientOrangeDark2', 'gradientOrangeDark3', 'gradientOrangeDark4']}
         start={{ x: 0, y: 1 }}
         end={{ x: 1, y: 0 }}
         style={{ minHeight: 250 + safeAreaInsets.top, paddingTop: safeAreaInsets.top }}

--- a/src/components/Screens/HomeScreen.tsx
+++ b/src/components/Screens/HomeScreen.tsx
@@ -44,7 +44,7 @@ function AssetsAccounts() {
   const displayAllAccounts = useSelector((state: RootState) => state.configuration.displayAllAccounts);
   const loading = useSelector((state: RootState) => state.loading.effects.accounts.getAccounts?.loading);
   const dispatch = useDispatch<RootDispatch>();
-  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle || colors.brandStyleOrange);
 
   const onSwitch = async (bool: boolean) => {
     dispatch.configuration.setDisplayAllAccounts(bool);
@@ -539,7 +539,7 @@ export default function HomeScreen() {
   const end = useSelector((state: RootState) => state.firefly.rangeDetails.end);
   const currentCode = useSelector((state: RootState) => state.currencies.currentCode);
   const dispatch = useDispatch<RootDispatch>();
-  const selectedTheme = useSelector((state: RootState) => state.configuration.selectedTheme);
+  const selectedTheme = useSelector((state: RootState) => state.configuration.selectedTheme || 'gradientOrange');
   const lightSelectedColor = colors[`${selectedTheme}Light`];
   const darkSelectedColor = colors[`${selectedTheme}Dark`];
   const gradientColors = colorScheme === 'light' ? lightSelectedColor : darkSelectedColor;

--- a/src/components/Screens/HomeScreen.tsx
+++ b/src/components/Screens/HomeScreen.tsx
@@ -540,8 +540,8 @@ export default function HomeScreen() {
   const currentCode = useSelector((state: RootState) => state.currencies.currentCode);
   const dispatch = useDispatch<RootDispatch>();
   const selectedTheme = useSelector((state: RootState) => state.configuration.selectedTheme || 'gradientOrange');
-  const lightSelectedColor = colors[`${selectedTheme}Light`];
-  const darkSelectedColor = colors[`${selectedTheme}Dark`];
+  const lightSelectedColor = colors[`${selectedTheme}Light`] || colors.gradientOrangeLight;
+  const darkSelectedColor = colors[`${selectedTheme}Dark`] || colors.gradientOrangeDark;
   const gradientColors = colorScheme === 'light' ? lightSelectedColor : darkSelectedColor;
 
   const renderIcons = [

--- a/src/components/Screens/HomeScreen.tsx
+++ b/src/components/Screens/HomeScreen.tsx
@@ -44,6 +44,7 @@ function AssetsAccounts() {
   const displayAllAccounts = useSelector((state: RootState) => state.configuration.displayAllAccounts);
   const loading = useSelector((state: RootState) => state.loading.effects.accounts.getAccounts?.loading);
   const dispatch = useDispatch<RootDispatch>();
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
 
   const onSwitch = async (bool: boolean) => {
     dispatch.configuration.setDisplayAllAccounts(bool);
@@ -98,7 +99,7 @@ function AssetsAccounts() {
           <AText fontSize={25} lineHeight={27} style={{ margin: 15 }} bold>
             {displayAllAccounts ? translate('home_all_accounts') : translate('home_accounts')}
           </AText>
-          <Switch style={{ marginHorizontal: 10 }} thumbColor="white" trackColor={{ false: '#767577', true: colors.brandStyle }} onValueChange={onSwitch} value={displayAllAccounts} />
+          <Switch style={{ marginHorizontal: 10 }} thumbColor="white" trackColor={{ false: '#767577', true: selectedBrandStyle }} onValueChange={onSwitch} value={displayAllAccounts} />
         </AStack>
         <AStack px={5} row justifyContent="space-between">
           <View style={{ flex: 1, alignItems: 'flex-start', paddingLeft: '5%' }}>
@@ -106,7 +107,7 @@ function AssetsAccounts() {
               <MaterialCommunityIcons
                 name="sort"
                 size={22}
-                color={lastPressed === 'left' ? colors.primary : colors.text}
+                color={lastPressed === 'left' ? selectedBrandStyle : colors.text}
               />
             </TouchableOpacity>
           </View>
@@ -115,7 +116,7 @@ function AssetsAccounts() {
               <MaterialCommunityIcons
                 name="sort"
                 size={22}
-                color={lastPressed === 'right' ? colors.primary : colors.text}
+                color={lastPressed === 'right' ? selectedBrandStyle : colors.text}
                 style={{ transform: [{ scaleX: -1 }] }}
               />
             </TouchableOpacity>
@@ -538,6 +539,11 @@ export default function HomeScreen() {
   const end = useSelector((state: RootState) => state.firefly.rangeDetails.end);
   const currentCode = useSelector((state: RootState) => state.currencies.currentCode);
   const dispatch = useDispatch<RootDispatch>();
+  const selectedTheme = useSelector((state: RootState) => state.configuration.selectedTheme);
+  const lightSelectedColor = colors[`${selectedTheme}Light`];
+  const darkSelectedColor = colors[`${selectedTheme}Dark`];
+  const gradientColors = colorScheme === 'light' ? lightSelectedColor : darkSelectedColor;
+
   const renderIcons = [
     <Ionicons key="wallet" name="wallet" size={22} color={colors.text} />,
     <Ionicons key="pricetag" name="pricetags" size={22} color={colors.text} />,
@@ -593,7 +599,7 @@ export default function HomeScreen() {
   return (useMemo(() => (
     <AView style={{ flex: 1 }}>
       <LinearGradient
-        colors={colorScheme === 'light' ? ['gradientOrangeLight1', 'gradientOrangeLight2', 'gradientOrangeLight3', 'gradientOrangeLight4'] : ['gradientOrangeDark1', 'gradientOrangeDark2', 'gradientOrangeDark3', 'gradientOrangeDark4']}
+        colors={gradientColors}
         start={{ x: 0, y: 1 }}
         end={{ x: 1, y: 0 }}
         style={{ minHeight: 250 + safeAreaInsets.top, paddingTop: safeAreaInsets.top }}

--- a/src/components/UI/ALibrary/AButton.tsx
+++ b/src/components/UI/ALibrary/AButton.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { ActivityIndicator, Pressable } from 'react-native';
+import { useSelector } from 'react-redux';
 import { AStyle } from './types';
 import { useThemeColors } from '../../../lib/common';
+import { RootState } from '../../../store';
 
 interface AButtonType {
   type?: 'primary' | 'secondary' | 'danger' | 'success' | 'warning' | 'info' | 'light' | 'dark' | 'transparent'
@@ -29,7 +31,8 @@ export default function AButton({
   testID = null,
 }: AButtonType) {
   const { colors } = useThemeColors();
-  const backgroundColor = colors[type];
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
+  const backgroundColor = type === 'primary' ? selectedBrandStyle : colors[type];
 
   return (
     <Pressable

--- a/src/components/UI/ALibrary/AButton.tsx
+++ b/src/components/UI/ALibrary/AButton.tsx
@@ -31,7 +31,7 @@ export default function AButton({
   testID = null,
 }: AButtonType) {
   const { colors } = useThemeColors();
-  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle || colors.brandStyleOrange);
   const backgroundColor = type === 'primary' ? selectedBrandStyle : colors[type];
 
   return (

--- a/src/components/UI/ALibrary/AInput.tsx
+++ b/src/components/UI/ALibrary/AInput.tsx
@@ -54,7 +54,7 @@ export default function AInput({
 }: AInputType) {
   const { colors } = useThemeColors();
   const [isFocused, setIsFocused] = React.useState(false);
-  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle || colors.brandStyleOrange);
   const handleFocus = (focusState: boolean, callback: () => void) => {
     setIsFocused(focusState);
     callback();

--- a/src/components/UI/ALibrary/AInput.tsx
+++ b/src/components/UI/ALibrary/AInput.tsx
@@ -4,10 +4,12 @@ import {
   TextInput,
   TextInputFocusEventData,
 } from 'react-native';
+import { useSelector } from 'react-redux';
 import { AStyle } from './types';
 import AStack from './AStack';
 import { useThemeColors } from '../../../lib/common';
 import AView from './AView';
+import { RootState } from '../../../store';
 
 type AInputType = {
   height?: number
@@ -52,9 +54,18 @@ export default function AInput({
 }: AInputType) {
   const { colors } = useThemeColors();
   const [isFocused, setIsFocused] = React.useState(false);
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
   const handleFocus = (focusState: boolean, callback: () => void) => {
     setIsFocused(focusState);
     callback();
+  };
+
+  const selectedBrandStyleWithAlpha = (hexColor, alpha) => {
+    const color = hexColor.replace('#', '');
+    const r = parseInt(color.substring(0, 2), 16);
+    const g = parseInt(color.substring(2, 4), 16);
+    const b = parseInt(color.substring(4, 6), 16);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
   };
 
   return (
@@ -63,8 +74,8 @@ export default function AInput({
       style={{
         width: '100%',
         borderRadius: 10,
-        borderColor: isFocused ? colors.brandStyle : colors.listBorderColor,
-        backgroundColor: isFocused ? 'rgba(255,85,51,0.10)' : 'transparent',
+        borderColor: isFocused ? selectedBrandStyle : colors.listBorderColor,
+        backgroundColor: isFocused ? selectedBrandStyleWithAlpha(selectedBrandStyle, 0.1) : 'transparent',
         borderWidth: 1,
         ...style,
       }}

--- a/src/components/UI/Filters.tsx
+++ b/src/components/UI/Filters.tsx
@@ -22,7 +22,7 @@ export default function Filters() {
   const range = useSelector((state: RootState) => state.firefly.rangeDetails.range);
   const accounts = useSelector((state: RootState) => state.accounts.accounts);
   const selectedAccountIds = useSelector((state: RootState) => state.accounts.selectedAccountIds);
-  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle || colors.brandStyleOrange);
   const {
     firefly: {
       setRange,

--- a/src/components/UI/Filters.tsx
+++ b/src/components/UI/Filters.tsx
@@ -22,6 +22,7 @@ export default function Filters() {
   const range = useSelector((state: RootState) => state.firefly.rangeDetails.range);
   const accounts = useSelector((state: RootState) => state.accounts.accounts);
   const selectedAccountIds = useSelector((state: RootState) => state.accounts.selectedAccountIds);
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
   const {
     firefly: {
       setRange,
@@ -70,7 +71,7 @@ export default function Filters() {
             }}
           >
             <View style={{
-              backgroundColor: currentCode === currency.attributes.code ? colors.brandStyle : colors.filterBorderColor,
+              backgroundColor: currentCode === currency.attributes.code ? selectedBrandStyle : colors.filterBorderColor,
               justifyContent: 'center',
               alignItems: 'center',
               borderRadius: 10,
@@ -151,7 +152,7 @@ export default function Filters() {
             }}
           >
             <View style={{
-              backgroundColor: selectedAccountIds?.includes(parseInt(account.id, 10)) ? colors.brandStyle : colors.filterBorderColor,
+              backgroundColor: selectedAccountIds?.includes(parseInt(account.id, 10)) ? selectedBrandStyle : colors.filterBorderColor,
               justifyContent: 'center',
               alignItems: 'center',
               borderRadius: 10,

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -5,7 +5,7 @@ export default {
   brandStyle70: 'rgba(175,175,175,0.7)',
   brandStyle20: 'rgba(203,203,203,0.4)',
   brandStyleSecond: '#ff6443',
-  brandStyle0: '#FF5533',
+  brandStyle0: '#7F00FF',
   brandStyle1: '#BEA6A0',
   brandStyle2: '#56423D',
   brandStyle3: '#3FA500',
@@ -25,15 +25,63 @@ export default {
   greyLight: '#6c6c6c',
 
   // New gradient colors
-  gradientOrangeLight1: 'rgb(255,211,195)',
-  gradientOrangeLight2: 'rgb(255,194,183)',
-  gradientOrangeLight3: 'rgb(248,199,193)',
-  gradientOrangeLight4: 'rgb(255,228,194)',
+  gradientOrangeLight: ['rgb(255,211,195)', 'rgb(255,194,183)', 'rgb(248,199,193)', 'rgb(255,228,194)'],
+  gradientOrangeDark: ['#790277', '#d30847', '#FF5533', '#efe96d'],
 
-  gradientOrangeDark1: '#790277',
-  gradientOrangeDark2: '#d30847',
-  gradientOrangeDark3: '#FF5533',
-  gradientOrangeDark4: '#efe96d',
+  gradientBlueLight: ['rgb(195,211,255)', 'rgb(183,194,255)', 'rgb(193,199,248)', 'rgb(194,228,255)'],
+  gradientBlueDark: ['#027790', '#0847d3', '#3355FF', '#6d96ef'],
+
+  gradientGreenLight: ['rgb(195,255,211)', 'rgb(183,255,194)', 'rgb(193,248,199)', 'rgb(194,255,228)'],
+  gradientGreenDark: ['#028a3d', '#03c464', '#2ecc71', '#7fdcae'],
+
+  gradientPurpleLight: ['rgb(225,195,255)', 'rgb(215,183,255)', 'rgb(223,193,248)', 'rgb(230,194,255)'],
+  gradientPurpleDark: ['#570290', '#8408d3', '#A933FF', '#be6def'],
+
+  gradientYellowLight: ['rgb(255,251,195)', 'rgb(255,248,183)', 'rgb(248,245,193)', 'rgb(255,255,194)'],
+  gradientYellowDark: ['#c9a601', '#ffcc00', '#ffd700', '#ffe56e'],
+
+  gradientPinkLight: ['rgb(255,195,233)', 'rgb(255,183,227)', 'rgb(248,193,235)', 'rgb(255,194,240)'],
+  gradientPinkDark: ['#902757', '#d3089c', '#FF33A8', '#ef6d96'],
+
+  gradientTealLight: ['rgb(195,255,251)', 'rgb(183,255,248)', 'rgb(193,248,245)', 'rgb(194,255,255)'],
+  gradientTealDark: ['#027c79', '#08b3a3', '#33FFDD', '#6defef'],
+
+  gradientRedLight: ['rgb(255,195,195)', 'rgb(255,183,183)', 'rgb(248,193,193)', 'rgb(255,194,194)'],
+  gradientRedDark: ['#7c0202', '#d30808', '#FF3333', '#ef6d6d'],
+
+  gradientBrownLight: ['rgb(210,180,140)', 'rgb(222,184,135)', 'rgb(139,69,19)', 'rgb(160,82,45)'],
+  gradientBrownDark: ['#4e2602', '#6b3a00', '#a0522d', '#cd7f32'],
+
+  gradientCyanLight: ['rgb(195,255,255)', 'rgb(183,255,255)', 'rgb(193,248,248)', 'rgb(194,255,255)'],
+  gradientCyanDark: ['#027a7a', '#08b3b3', '#33FFFF', '#6defff'],
+
+  gradientMintLight: ['rgb(195,255,245)', 'rgb(183,255,239)', 'rgb(193,248,240)', 'rgb(194,255,250)'],
+  gradientMintDark: ['#027a6b', '#08b386', '#33FFAA', '#6defc3'],
+
+  gradientLavenderLight: ['rgb(235,195,255)', 'rgb(223,183,255)', 'rgb(233,193,248)', 'rgb(244,194,255)'],
+  gradientLavenderDark: ['#6a0290', '#a308d3', '#D633FF', '#d66def'],
+
+  gradientGoldLight: ['rgb(255,231,195)', 'rgb(255,223,183)', 'rgb(248,219,193)', 'rgb(255,238,194)'],
+  gradientGoldDark: ['#907202', '#d3a008', '#FFB533', '#e6bc5d'],
+
+  gradientPeachLight: ['rgb(255,213,195)', 'rgb(255,203,183)', 'rgb(248,209,193)', 'rgb(255,218,194)'],
+  gradientPeachDark: ['#906502', '#d38908', '#FF8833', '#e6a55d'],
+
+  // New accent colors
+  brandStyleOrange: '#FF5533',
+  brandStyleBlue: '#3355FF',
+  brandStyleGreen: '#2ecc71',
+  brandStylePurple: '#A933FF',
+  brandStyleYellow: '#ffd700',
+  brandStylePink: '#FF33A8',
+  brandStyleTeal: '#33FFDD',
+  brandStyleRed: '#FF3333',
+  brandStyleBrown: '#a0522d',
+  brandStyleCyan: '#33FFFF',
+  brandStyleMint: '#33FFAA',
+  brandStyleLavender: '#D633FF',
+  brandStyleGold: '#FFB533',
+  brandStylePeach: '#FF8833',
 
   dark: {
     text: 'white',

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -23,6 +23,18 @@ export default {
   blurAndroidHeader: 'rgba(40,40,40,0.16)',
   brandNeutralFix: '#e3e3e3',
   greyLight: '#6c6c6c',
+
+  // New gradient colors
+  gradientOrangeLight1: 'rgb(255,211,195)',
+  gradientOrangeLight2: 'rgb(255,194,183)',
+  gradientOrangeLight3: 'rgb(248,199,193)',
+  gradientOrangeLight4: 'rgb(255,228,194)',
+
+  gradientOrangeDark1: '#790277',
+  gradientOrangeDark2: '#d30847',
+  gradientOrangeDark3: '#FF5533',
+  gradientOrangeDark4: '#efe96d',
+
   dark: {
     text: 'white',
     textOpposite: 'black',

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -25,63 +25,67 @@ export default {
   greyLight: '#6c6c6c',
 
   // New gradient colors
+  gradientRedLight: ['rgb(255,170,170)', 'rgb(255,158,158)', 'rgb(250,173,173)', 'rgb(255,174,174)'],
+  gradientRedDark: ['#7c0202', '#d30808', '#FF3333', '#ef6d6d'],
+
   gradientOrangeLight: ['rgb(255,211,195)', 'rgb(255,194,183)', 'rgb(248,199,193)', 'rgb(255,228,194)'],
   gradientOrangeDark: ['#790277', '#d30847', '#FF5533', '#efe96d'],
 
-  gradientBlueLight: ['rgb(195,211,255)', 'rgb(183,194,255)', 'rgb(193,199,248)', 'rgb(194,228,255)'],
-  gradientBlueDark: ['#027790', '#0847d3', '#3355FF', '#6d96ef'],
+  gradientLightOrangeLight: ['rgb(255,230,205)', 'rgb(255,220,190)', 'rgb(255,210,180)', 'rgb(255,220,200)'],
+  gradientLightOrangeDark: ['#ffa07a', '#ff8c00', '#ff7f50', '#ff6347'],
+
+  gradientGoldLight: ['rgb(205,173,0)', 'rgb(218,165,32)', 'rgb(238,221,130)', 'rgb(255,215,0)'],
+  gradientGoldDark: ['#b8860b', '#d2b48c', '#daa520', '#ffd700'],
+
+  gradientYellowLight: ['rgb(255,255,150)', 'rgb(255,255,120)', 'rgb(255,255,100)', 'rgb(255,255,180)'],
+  gradientYellowDark: ['#ffeb3b', '#fdd835', '#fbc02d', '#f9a825'],
+
+  gradientLightYellowLight: ['rgb(255,255,230)', 'rgb(255,255,210)', 'rgb(255,255,190)', 'rgb(255,255,220)'],
+  gradientLightYellowDark: ['#ebebd3', '#ebebc1', '#e4e4ab', '#ececcb'],
+
+  gradientDarkGreenLight: ['rgb(195,225,195)', 'rgb(183,210,183)', 'rgb(193,218,193)', 'rgb(194,230,194)'],
+  gradientDarkGreenDark: ['#014d00', '#026200', '#038200', '#059900'],
 
   gradientGreenLight: ['rgb(195,255,211)', 'rgb(183,255,194)', 'rgb(193,248,199)', 'rgb(194,255,228)'],
   gradientGreenDark: ['#028a3d', '#03c464', '#2ecc71', '#7fdcae'],
 
-  gradientPurpleLight: ['rgb(225,195,255)', 'rgb(215,183,255)', 'rgb(223,193,248)', 'rgb(230,194,255)'],
-  gradientPurpleDark: ['#570290', '#8408d3', '#A933FF', '#be6def'],
+  gradientMintLight: ['#E5FFF5', '#D4FFEB', '#C3FFE1', '#B2FFE7', '#A1FFE3', '#90FFE9', '#7FFFE5', '#6FFFE1', '#5FFFD7', '#33FFAA'],
+  gradientMintDark: ['#027a6b', '#08b386', '#33FFAA', '#6defc3'],
 
-  gradientYellowLight: ['rgb(255,251,195)', 'rgb(255,248,183)', 'rgb(248,245,193)', 'rgb(255,255,194)'],
-  gradientYellowDark: ['#c9a601', '#ffcc00', '#ffd700', '#ffe56e'],
-
-  gradientPinkLight: ['rgb(255,195,233)', 'rgb(255,183,227)', 'rgb(248,193,235)', 'rgb(255,194,240)'],
-  gradientPinkDark: ['#902757', '#d3089c', '#FF33A8', '#ef6d96'],
+  gradientBlueLight: ['rgb(195,211,255)', 'rgb(183,194,255)', 'rgb(193,199,248)', 'rgb(194,228,255)'],
+  gradientBlueDark: ['#027790', '#0847d3', '#3355FF', '#6d96ef'],
 
   gradientTealLight: ['rgb(195,255,251)', 'rgb(183,255,248)', 'rgb(193,248,245)', 'rgb(194,255,255)'],
   gradientTealDark: ['#027c79', '#08b3a3', '#33FFDD', '#6defef'],
 
-  gradientRedLight: ['rgb(255,195,195)', 'rgb(255,183,183)', 'rgb(248,193,193)', 'rgb(255,194,194)'],
-  gradientRedDark: ['#7c0202', '#d30808', '#FF3333', '#ef6d6d'],
-
-  gradientBrownLight: ['rgb(210,180,140)', 'rgb(222,184,135)', 'rgb(139,69,19)', 'rgb(160,82,45)'],
-  gradientBrownDark: ['#4e2602', '#6b3a00', '#a0522d', '#cd7f32'],
-
   gradientCyanLight: ['rgb(195,255,255)', 'rgb(183,255,255)', 'rgb(193,248,248)', 'rgb(194,255,255)'],
   gradientCyanDark: ['#027a7a', '#08b3b3', '#33FFFF', '#6defff'],
 
-  gradientMintLight: ['rgb(195,255,245)', 'rgb(183,255,239)', 'rgb(193,248,240)', 'rgb(194,255,250)'],
-  gradientMintDark: ['#027a6b', '#08b386', '#33FFAA', '#6defc3'],
+  gradientPurpleLight: ['rgb(225,195,255)', 'rgb(215,183,255)', 'rgb(223,193,248)', 'rgb(230,194,255)'],
+  gradientPurpleDark: ['#570290', '#8408d3', '#A933FF', '#be6def'],
 
   gradientLavenderLight: ['rgb(235,195,255)', 'rgb(223,183,255)', 'rgb(233,193,248)', 'rgb(244,194,255)'],
   gradientLavenderDark: ['#6a0290', '#a308d3', '#D633FF', '#d66def'],
 
-  gradientGoldLight: ['rgb(255,231,195)', 'rgb(255,223,183)', 'rgb(248,219,193)', 'rgb(255,238,194)'],
-  gradientGoldDark: ['#907202', '#d3a008', '#FFB533', '#e6bc5d'],
-
-  gradientPeachLight: ['rgb(255,213,195)', 'rgb(255,203,183)', 'rgb(248,209,193)', 'rgb(255,218,194)'],
-  gradientPeachDark: ['#906502', '#d38908', '#FF8833', '#e6a55d'],
+  gradientPinkLight: ['rgb(255,195,233)', 'rgb(255,183,227)', 'rgb(248,193,235)', 'rgb(255,194,240)'],
+  gradientPinkDark: ['#902757', '#d3089c', '#FF33A8', '#ef6d96'],
 
   // New accent colors
-  brandStyleOrange: '#FF5533',
-  brandStyleBlue: '#3355FF',
-  brandStyleGreen: '#2ecc71',
-  brandStylePurple: '#A933FF',
-  brandStyleYellow: '#ffd700',
-  brandStylePink: '#FF33A8',
-  brandStyleTeal: '#33FFDD',
   brandStyleRed: '#FF3333',
-  brandStyleBrown: '#a0522d',
-  brandStyleCyan: '#33FFFF',
+  brandStyleOrange: '#FF5533',
+  brandStyleLightOrange: '#ff8c00',
+  brandStyleGold: '#DCA519',
+  brandStyleYellow: '#ffec3d',
+  brandStyleLightYellow: '#EEEEBA',
+  brandStyleDarkGreen: '#038200',
+  brandStyleGreen: '#2ecc71',
   brandStyleMint: '#33FFAA',
+  brandStyleBlue: '#3355FF',
+  brandStyleTeal: '#2EE2C4',
+  brandStyleCyan: '#2BE2E2',
+  brandStylePurple: '#A933FF',
   brandStyleLavender: '#D633FF',
-  brandStyleGold: '#FFB533',
-  brandStylePeach: '#FF8833',
+  brandStylePink: '#FF33A8',
 
   dark: {
     text: 'white',

--- a/src/i18n/locale/translations/de-DE.ts
+++ b/src/i18n/locale/translations/de-DE.ts
@@ -47,7 +47,7 @@ export default {
   auth_form_submit_button_initial: 'Einloggen',
   auth_form_submit_button_loading: 'Wird eingereicht...',
   auth_form_biometrics_lock: 'Biometrische Sperre',
-  home_accounts: 'Asset-Konten',
+  home_accounts: 'Bestandskonten',
   layout_new_update_header: 'Neues Update verfügbar',
   layout_new_update_body_text: 'Du kannst später jederzeit im Einstellungen-Tab aktualisieren.',
   layout_new_update_cancel_button: 'Abbrechen',
@@ -155,4 +155,5 @@ export default {
   // from 0.19.0
   configuration_theme: 'Anpassung',
   configuration_theme_selection: 'Farbthema ändern',
+  configuration_theme_title: 'Farben',
 };

--- a/src/i18n/locale/translations/de-DE.ts
+++ b/src/i18n/locale/translations/de-DE.ts
@@ -150,5 +150,9 @@ export default {
   bills_not_expected: 'Nicht erwartet',
   transaction_form_bill_label: 'Rechnung',
   configuration_transaction_form: 'Transaktionsformular',
-  close_after_transaction: 'Schließe das Transaktionsformular nach dem Einreichen'
+  close_after_transaction: 'Transaktionsformular nach Einreichen schließen',
+
+  // from 0.19.0
+  configuration_theme: 'Anpassung',
+  configuration_theme_selection: 'Farbthema ändern',
 };

--- a/src/i18n/locale/translations/en-US.ts
+++ b/src/i18n/locale/translations/en-US.ts
@@ -150,5 +150,9 @@ export default {
   bills_not_expected: 'Not expected',
   transaction_form_bill_label: 'Bill',
   configuration_transaction_form: 'Transaction Form',
-  close_after_transaction: 'Close transaction form after submission'
+  close_after_transaction: 'Close transaction form after submission',
+
+  // from 0.19.0
+  configuration_theme: 'Customization',
+  configuration_theme_selection: 'Change color theme',
 };

--- a/src/i18n/locale/translations/en-US.ts
+++ b/src/i18n/locale/translations/en-US.ts
@@ -155,4 +155,5 @@ export default {
   // from 0.19.0
   configuration_theme: 'Customization',
   configuration_theme_selection: 'Change color theme',
+  configuration_theme_title: 'Color themes',
 };

--- a/src/i18n/locale/translations/es-ES.ts
+++ b/src/i18n/locale/translations/es-ES.ts
@@ -62,4 +62,9 @@ export default {
 
   // from 0.7.0
   home_budgets: 'Presupuestos',
+
+  // from 0.19.0
+  configuration_theme: 'Personalización',
+  configuration_theme_selection: 'Cambiar tema de color',
+  configuration_theme_title: 'Temas de color',
 };

--- a/src/i18n/locale/translations/fr-FR.ts
+++ b/src/i18n/locale/translations/fr-FR.ts
@@ -85,12 +85,12 @@ export default {
   home_header_time_range_q: 'T', // Put an abbreviation that best represents a quarter
   home_header_time_range_s: 'S', // Put an abbreviation that best represents a semiannual
 
-// from 0.6.0
+  // from 0.6.0
   balance: 'Solde',
   history: 'Historique',
   home_categories: 'Catégories',
   home_net_worth: 'Valeur Nette',
-  
+
   // from 0.7.0
   home_budgets: 'Budgets',
   configuration_ui: 'Interface Utilisateur',
@@ -102,7 +102,7 @@ export default {
   auth_create_new_personal_access_token: 'Créer un nouveau Jeton d\'Accès Personnel dans l\'onglet OAuth, ici :',
   oauth_wrong_token_error_description: 'Échec de la validation de l\'accessToken, veuillez vérifier votre jeton ou l\'URL du backend.',
   transaction_screen_edit_title: 'Modifier la Transaction',
-  
+
   // from 0.9.0
   transaction_form_foreign_currency_label: 'Devise étrangère',
   transaction_form_group_title_label: 'Description de la transaction divisée',
@@ -110,39 +110,39 @@ export default {
   transaction_form_group_title_helper: 'Si vous créez une transaction divisée, il doit y avoir une description globale pour toutes les divisions de la transaction.',
   configuration_review_app_ios: 'Évaluer Abacus sur l\'AppStore',
   configuration_review_app_android: 'Évaluer Abacus sur Google Play',
-  
+
   // from 0.9.2
   assets_history_chart: 'Graphique des comptes',
   balance_history_chart: 'Graphique de la Valeur Nette',
   balance_history_chart_no_data: 'Pour accéder à ce graphique, veuillez mettre à jour FireflyIII à la dernière version.',
   account_not_included_in_net_worth: '* Compte non inclus dans la Valeur Nette.',
-  
+
   // from 0.10.0
   period: 'Période',
   currency: 'Devise',
-  
+
   home_all_accounts: 'Tous les Comptes',
-  
+
   // from 0.10.3
   router_back_button: 'Retour',
   transaction_clone: 'Cloner',
   transaction_delete: 'Supprimer',
-  
+
   // from 0.11.0
   configuration_credentials: 'Identifiants',
   configuration_manage_credentials: 'Gérer les Identifiants',
   configuration_credentials_add_button: 'Ajouter un Identifiant',
   logout: 'Déconnexion',
-  
+
   // from 0.12.0
   credential_clear_confirm_button: 'Supprimer',
   credential_clear_alert_title: 'Êtes-vous sûr ?',
   credential_clear_cancel_button: 'Annuler',
   go_to_credentials: 'Aller aux Identifiants',
-  
+
   configuration_logout_alert_title: 'Déconnexion',
   load_more: 'Charger plus',
-  
+
   // from X.X.X
   home_bills: 'Factures',
   home_piggy_banks: 'Tirelires',
@@ -150,5 +150,10 @@ export default {
   bills_not_expected: 'Non attendu',
   transaction_form_bill_label: 'Facture',
   configuration_transaction_form: 'Formulaire',
-  close_after_transaction: 'Fermer la transaction après l\'avoir envoyé'
+  close_after_transaction: 'Fermer la transaction après l\'avoir envoyé',
+
+  // from 0.19.0
+  configuration_theme: 'Personnalisation',
+  configuration_theme_selection: 'Changer le thème de couleur',
+  configuration_theme_title: 'Thèmes de couleur',
 };

--- a/src/i18n/locale/translations/id-ID.ts
+++ b/src/i18n/locale/translations/id-ID.ts
@@ -85,4 +85,9 @@ export default {
 
   // from 0.7.0
   home_budgets: 'Anggaran',
+
+  // from 0.19.0
+  configuration_theme: 'Kustomisasi',
+  configuration_theme_selection: 'Ganti tema warna',
+  configuration_theme_title: 'Tema warna',
 };

--- a/src/i18n/locale/translations/it-IT.ts
+++ b/src/i18n/locale/translations/it-IT.ts
@@ -47,7 +47,7 @@ export default {
   auth_form_submit_button_loading: 'Invio in corso...',
   home_accounts: 'Conti',
   layout_new_update_header: 'Nuovo aggiornamento disponibile',
-  layout_new_update_body_text: 'Puoi sempre aggiornare dopo dal pannello \"Impostazioni\".',
+  layout_new_update_body_text: 'Puoi sempre aggiornare dopo dal pannello "Impostazioni".',
   layout_new_update_cancel_button: 'Annulla',
   layout_new_update_update_button: 'Aggiorna adesso',
 
@@ -146,4 +146,9 @@ export default {
   bills_paid: 'Pagato',
   bills_not_expected: 'Non attesa',
   transaction_form_bill_label: 'Bolletta',
+
+  // from 0.19.0
+  configuration_theme: 'Personalizzazione',
+  configuration_theme_selection: 'Cambia tema colore',
+  configuration_theme_title: 'Temi colore',
 };

--- a/src/i18n/locale/translations/pt-BR.ts
+++ b/src/i18n/locale/translations/pt-BR.ts
@@ -130,4 +130,9 @@ export default {
   router_back_button: 'Voltar',
   transaction_clone: 'Clonar',
   transaction_delete: 'Apagar',
+
+  // from 0.19.0
+  configuration_theme: 'Personalização',
+  configuration_theme_selection: 'Alterar tema de cores',
+  configuration_theme_title: 'Temas de cores',
 };

--- a/src/i18n/locale/translations/ru-RU.ts
+++ b/src/i18n/locale/translations/ru-RU.ts
@@ -126,7 +126,7 @@ export default {
 
   home_all_accounts: 'Все счета',
 
-   // from 0.10.3
+  // from 0.10.3
   router_back_button: 'Назад',
   transaction_clone: 'Клонировать',
   transaction_delete: 'Удалить',
@@ -151,4 +151,9 @@ export default {
   bills_paid: 'Оплаченные',
   bills_not_expected: 'Не ожидается',
   transaction_form_bill_label: 'Счёт',
+
+  // from 0.19.0
+  configuration_theme: 'Настройка',
+  configuration_theme_selection: 'Изменить цветовую тему',
+  configuration_theme_title: 'Цветовые темы',
 };

--- a/src/i18n/locale/translations/sl-SI.ts
+++ b/src/i18n/locale/translations/sl-SI.ts
@@ -123,4 +123,9 @@ export default {
   // from 0.10.0
   period: 'Obdobje',
   currency: 'Valuta',
+
+  // from 0.19.0
+  configuration_theme: 'Prilagoditev',
+  configuration_theme_selection: 'Spremeni barvno temo',
+  configuration_theme_title: 'Barvne teme',
 };

--- a/src/i18n/locale/translations/vi-VN.ts
+++ b/src/i18n/locale/translations/vi-VN.ts
@@ -130,4 +130,9 @@ export default {
   router_back_button: 'Back',
   transaction_clone: 'Clone',
   transaction_delete: 'Delete',
+
+  // from 0.19.0
+  configuration_theme: 'Tùy chỉnh',
+  configuration_theme_selection: 'Thay đổi chủ đề màu',
+  configuration_theme_title: 'Chủ đề màu',
 };

--- a/src/i18n/locale/translations/zh-CN.ts
+++ b/src/i18n/locale/translations/zh-CN.ts
@@ -130,4 +130,9 @@ export default {
   router_back_button: '返回',
   transaction_clone: '克隆',
   transaction_delete: '删除',
+
+  // from 0.19.0
+  configuration_theme: '定制',
+  configuration_theme_selection: '更改颜色主题',
+  configuration_theme_title: '颜色主题',
 };

--- a/src/models/configuration.ts
+++ b/src/models/configuration.ts
@@ -3,6 +3,7 @@ import axios, { AxiosResponse } from 'axios';
 
 import { RootModel } from './index';
 import { convertKeysToCamelCase } from '../lib/common';
+import colors from '../constants/colors';
 
 type ConfigurationStateType = {
   backendURL: string
@@ -13,6 +14,8 @@ type ConfigurationStateType = {
   apiVersion: string
   serverVersion: string
   closeTransactionScreen: boolean
+  selectedTheme: string
+  selectedBrandStyle: string
 }
 
 type FireflyIIIApiResponse = {
@@ -49,6 +52,8 @@ const INITIAL_STATE = {
   apiVersion: '',
   serverVersion: '',
   closeTransactionScreen: false,
+  selectedTheme: 'gradientOrange',
+  selectedBrandStyle: colors.brandStyleOrange,
 } as ConfigurationStateType;
 
 export default createModel<RootModel>()({
@@ -107,6 +112,19 @@ export default createModel<RootModel>()({
       return {
         ...state,
         closeTransactionScreen,
+      };
+    },
+    setSelectedTheme(state, selectedTheme: string): ConfigurationStateType {
+      return {
+        ...state,
+        selectedTheme,
+      };
+    },
+
+    setSelectedBrandStyle(state, selectedBrandStyle: string): ConfigurationStateType {
+      return {
+        ...state,
+        selectedBrandStyle,
       };
     },
   },

--- a/src/models/firefly.ts
+++ b/src/models/firefly.ts
@@ -293,45 +293,55 @@ export default createModel<RootModel>()({
         accounts: {
           selectedAccountIds,
         },
+        configuration: {
+          selectedBrandStyle,
+        },
       } = rootState;
 
       const accountIdsParam = (selectedAccountIds && selectedAccountIds.length > 0) ? `&accounts[]=${selectedAccountIds.join('&accounts[]=')}` : '';
       const { data: accounts } = await dispatch.configuration.apiFetch({ url: `/api/v1/chart/account/overview?start=${start}&end=${end}${accountIdsParam}` }) as { data: AssetAccountType[] };
       let colorIndex = 0;
 
-      accounts
-        .forEach((v, index) => {
+      accounts.forEach((v, index) => {
+        if (index === 0) {
+          accounts[index].color = selectedBrandStyle;
+        } else {
           if (colorIndex >= 6) {
             colorIndex = 0;
           }
           accounts[index].color = colors[`brandStyle${colorIndex}`];
-          accounts[index].colorScheme = `chart${colorIndex}`;
           colorIndex += 1;
-          accounts[index].entries = range > 3 ? Object.keys(v.entries)
-            .filter((e, i) => i % 2 === 0)
-            .filter((e, i) => i % 2 === 0)
-            .filter((e, i) => i % 2 === 0)
-            .map((key) => {
-              const value = parseFloat(accounts[index].entries[key]);
-              const date = new Date(key);
+        }
+        accounts[index].colorScheme = `chart${colorIndex}`;
+        accounts[index].colorScheme = `chart${colorIndex}`;
+        colorIndex += 1;
+        accounts[index].colorScheme = `chart${colorIndex}`;
+        colorIndex += 1;
+        accounts[index].entries = range > 3 ? Object.keys(v.entries)
+          .filter((e, i) => i % 2 === 0)
+          .filter((e, i) => i % 2 === 0)
+          .filter((e, i) => i % 2 === 0)
+          .map((key) => {
+            const value = parseFloat(accounts[index].entries[key]);
+            const date = new Date(key);
 
-              return {
-                x: +date,
-                y: value,
-              };
-            })
-            : Object.keys(v.entries).map((key) => {
-              const value = parseFloat(accounts[index].entries[key]);
-              const date = new Date(key);
+            return {
+              x: +date,
+              y: value,
+            };
+          })
+          : Object.keys(v.entries).map((key) => {
+            const value = parseFloat(accounts[index].entries[key]);
+            const date = new Date(key);
 
-              return {
-                x: +date,
-                y: value,
-              };
-            });
-          accounts[index].maxY = maxBy(accounts[index].entries, (o: { x: number, y: number }) => (o.y)).y;
-          accounts[index].minY = minBy(accounts[index].entries, (o: { x: number, y: number }) => (o.y)).y;
-        });
+            return {
+              x: +date,
+              y: value,
+            };
+          });
+        accounts[index].maxY = maxBy(accounts[index].entries, (o: { x: number, y: number }) => (o.y)).y;
+        accounts[index].minY = minBy(accounts[index].entries, (o: { x: number, y: number }) => (o.y)).y;
+      });
 
       dispatch.firefly.setData({ accounts: accounts.filter((account) => account.currencyCode === currentCode) });
     },

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -79,7 +79,7 @@ const styles = StyleSheet.create({
 function TabBarPrimaryButton() {
   const navigation = useNavigation();
   const { colors } = useThemeColors();
-  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle || colors.brandStyleOrange);
 
   return (
     <AStack justifyContent="flex-start">
@@ -227,7 +227,7 @@ function PrimaryButtonComponent() {
 
 function Home() {
   const { colors } = useThemeColors();
-  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle || colors.brandStyleOrange);
 
   return (
     <>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -17,7 +17,8 @@ import {
 import {
   StyleSheet, Platform, View, Pressable,
 } from 'react-native';
-
+import { useSelector } from 'react-redux';
+import { RootState } from '../store';
 import translate from '../i18n/locale';
 import { useThemeColors } from '../lib/common';
 
@@ -32,6 +33,7 @@ import TransactionsScreen from '../components/Screens/TransactionsScreen';
 import TransactionDetailScreen from '../components/Screens/TransactionDetailScreen';
 import ConfigurationScreen from '../components/Screens/ConfigurationScreen';
 import CredentialsScreen from '../components/Screens/CredentialsScreen';
+import ColorSelectionScreen from '../components/Screens/ColorSelectionScreen';
 
 // UI components
 import ABlurView from '../components/UI/ALibrary/ABlurView';
@@ -77,12 +79,13 @@ const styles = StyleSheet.create({
 function TabBarPrimaryButton() {
   const navigation = useNavigation();
   const { colors } = useThemeColors();
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
 
   return (
     <AStack justifyContent="flex-start">
       <AIconButton
         testID="navigation_create_transaction"
-        backgroundColor={colors.brandStyle}
+        backgroundColor={selectedBrandStyle}
         icon={<AntDesign name="plus" color="white" size={22} />}
         onPress={() => navigation.dispatch(
           CommonActions.navigate({
@@ -224,6 +227,7 @@ function PrimaryButtonComponent() {
 
 function Home() {
   const { colors } = useThemeColors();
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle);
 
   return (
     <>
@@ -232,7 +236,7 @@ function Home() {
         screenOptions={() => ({
           tabBarInactiveBackgroundColor: colors.tabBackgroundColor,
           tabBarActiveBackgroundColor: colors.tabBackgroundColor,
-          tabBarActiveTintColor: colors.brandStyle,
+          tabBarActiveTintColor: selectedBrandStyle,
           tabBarInactiveTintColor: colors.tabInactiveDarkLight,
           tabBarHideOnKeyboard: true,
           headerShown: false,
@@ -329,6 +333,23 @@ export default function Index() {
         <Stack.Screen
           name="dashboard"
           component={Home}
+        />
+        <Stack.Screen
+          name="ColorSelectionScreen"
+          component={ColorSelectionScreen}
+          options={{
+            headerShown: true,
+            headerTitle: translate('configuration_theme_title'),
+            headerBackTitleVisible: true,
+            headerBackTitle: translate('router_back_button'),
+            headerBackTitleStyle: {
+              fontFamily: 'Montserrat-Bold',
+            },
+            headerTintColor: colors.text,
+            headerStyle: {
+              backgroundColor: colors.tileBackgroundColor,
+            },
+          }}
         />
         <ModalStack.Group
           screenOptions={{


### PR DESCRIPTION
Hey Victor,

I now added the feature which I requested earlier. https://github.com/victorbalssa/abacus/issues/319#issue-2413149510

Main changes are:

- New Color Selection Screen in the Configuration Screen:
  - Here you can select a color that is saved to redux storage. Even after a restart the selected color is still selected.

- The gradients are now changed into a compacted version, so you only have to declare them in colors.ts

- I added translations for all available languages for my feature

- Gradients are linked to Accent Color, when I change to a color, the gradient on the Home Screen as well as the colors for the Buttons, Graphs (only first graph, the others are random) and Switches change too.

- I changed the TransactionForm Input Background to a more transparent version of the selected Color (That technically is the same as before but now with different colors)

<img src="https://github.com/user-attachments/assets/6b3819d0-86a3-4699-b5ad-ae091da50f56" alt="Simulator Screenshot - iPhone 15 - 2024-07-17 at 21 46 45" width="300" />

<img src="https://github.com/user-attachments/assets/ca707bd4-e989-404d-ada4-348fc0016b09" alt="Simulator Screenshot - iPhone 15 - 2024-07-17 at 21 46 28" width="300" />

<img src="https://github.com/user-attachments/assets/164598ac-462e-48a3-84c8-6a5d399bc7a2" alt="Simulator Screenshot - iPhone 15 - 2024-07-17 at 21 47 08" width="300" />

If there are any suggestions or bugs, do not hesitate to contact me!

Best regards,
Marcel