### PR TITLE
Autocomplete transaction information when selecting the description of a previous transaction

### DIFF
--- a/src/components/Forms/TransactionSplitForm.tsx
+++ b/src/components/Forms/TransactionSplitForm.tsx
@@ -32,6 +32,7 @@ export default function TransactionSplitForm({
 }) {
   const [locale] = getLocales();
   const displayForeignCurrency = useSelector((state: RootState) => state.configuration.displayForeignCurrency);
+  const autocompleteTransaction = useSelector((state: RootState) => state.configuration.autocompleteTransaction);
   const dispatch = useDispatch<RootDispatch>();
   const { colorScheme, colors } = useThemeColors();
   const [formData, setData] = useState<TransactionSplitType>({
@@ -70,6 +71,32 @@ export default function TransactionSplitForm({
       };
       dispatch.transactions.setTransactionSplitByIndex(index, newSplit);
       return newSplit;
+    });
+  };
+
+  const handleAutocompleteDescription = async (autocomplete) => {
+    let updates: Partial<TransactionSplitType> = {
+      description: autocomplete.name,
+    };
+
+    if (autocompleteTransaction) {
+      const existingTransaction = await dispatch.transactions.getTransaction(autocomplete.transactionGroupId);
+      updates = {
+        ...updates,
+        sourceId: existingTransaction.attributes.transactions[0].sourceId,
+        sourceName: existingTransaction.attributes.transactions[0].sourceName,
+        currencyCode: existingTransaction.attributes.transactions[0].currencyCode,
+        currencySymbol: existingTransaction.attributes.transactions[0].currencySymbol,
+        destinationId: existingTransaction.attributes.transactions[0].destinationId,
+        destinationName: existingTransaction.attributes.transactions[0].destinationName,
+        categoryId: existingTransaction.attributes.transactions[0].categoryId,
+        categoryName: existingTransaction.attributes.transactions[0].categoryName,
+      };
+    }
+
+    setTransaction({
+      ...formData,
+      ...updates,
     });
   };
 
@@ -298,10 +325,7 @@ export default function TransactionSplitForm({
             description: value,
           });
         }}
-        onSelectAutocomplete={(autocomplete) => setTransaction({
-          ...formData,
-          description: autocomplete.name,
-        })}
+        onSelectAutocomplete={handleAutocompleteDescription}
         InputRightElement={deleteBtn(['description'])}
         routeApi="transactions"
       />

--- a/src/components/Screens/ConfigurationScreen.tsx
+++ b/src/components/Screens/ConfigurationScreen.tsx
@@ -33,6 +33,7 @@ import {
 export default function ConfigurationScreen({ navigation }: ScreenType) {
   const { colors } = useThemeColors();
   const closeTransactionScreen = useSelector((state: RootState) => state.configuration.closeTransactionScreen);
+  const autocompleteAccounts = useSelector((state: RootState) => state.configuration.autocompleteTransaction);
   const safeAreaInsets = useSafeAreaInsets();
   const backendURL = useSelector((state: RootState) => state.configuration.backendURL);
   const useBiometricAuth = useSelector((state: RootState) => state.configuration.useBiometricAuth);
@@ -106,8 +107,13 @@ export default function ConfigurationScreen({ navigation }: ScreenType) {
     );
   };
 
-  const handleCheckBoxChange = async (bool: boolean) => {
+  const handleCloseFormCheckBoxChange = async (bool: boolean) => {
     dispatch.configuration.setCloseTransactionScreen(bool);
+    return Promise.resolve();
+  };
+
+  const handleAutocompleteAccountsCheckBoxChange = async (bool: boolean) => {
+    dispatch.configuration.setAutocompleteTransaction(bool);
     return Promise.resolve();
   };
 
@@ -305,7 +311,28 @@ export default function ConfigurationScreen({ navigation }: ScreenType) {
           }}
         >
           <AText fontSize={14}>{translate('close_after_transaction')}</AText>
-          <Switch thumbColor="white" trackColor={{ false: '#767577', true: selectedBrandStyle }} onValueChange={handleCheckBoxChange} value={closeTransactionScreen} />
+          <Switch thumbColor="white" trackColor={{ false: '#767577', true: selectedBrandStyle }} onValueChange={handleCloseFormCheckBoxChange} value={closeTransactionScreen} />
+        </AStack>
+      </AView>
+      <AView
+        style={{
+          borderTopWidth: 0.5,
+          borderBottomWidth: 0.5,
+          borderColor: colors.listBorderColor,
+          backgroundColor: colors.tileBackgroundColor,
+        }}
+      >
+        <AStack
+          row
+          justifyContent="space-between"
+          style={{
+            paddingHorizontal: 10,
+            paddingVertical: 5,
+            marginLeft: 10,
+          }}
+        >
+          <AText fontSize={14} maxWidth="80%">{translate('configuration_autocomplete_transaction')}</AText>
+          <Switch thumbColor="white" trackColor={{ false: '#767577', true: selectedBrandStyle }} onValueChange={handleAutocompleteAccountsCheckBoxChange} value={autocompleteAccounts} />
         </AStack>
       </AView>
 

--- a/src/i18n/locale/translations/en-US.ts
+++ b/src/i18n/locale/translations/en-US.ts
@@ -165,4 +165,7 @@ export default {
   filters_screen_title: 'Filters',
   credentials_done_button: 'Done',
   credentials_edit_button: 'Edit',
+
+  // from X.X.X
+  configuration_autocomplete_transaction: 'Autocomplete transaction information when selecting a previous description', // TODO: explain better
 };

--- a/src/models/configuration.ts
+++ b/src/models/configuration.ts
@@ -14,6 +14,7 @@ type ConfigurationStateType = {
   apiVersion: string
   serverVersion: string
   closeTransactionScreen: boolean
+  autocompleteTransaction: boolean
   selectedTheme: string
   selectedBrandStyle: string
 }
@@ -52,6 +53,7 @@ const INITIAL_STATE = {
   apiVersion: '',
   serverVersion: '',
   closeTransactionScreen: false,
+  autocompleteTransaction: false,
   selectedTheme: 'gradientOrange',
   selectedBrandStyle: colors.brandStyleOrange,
 } as ConfigurationStateType;
@@ -112,6 +114,12 @@ export default createModel<RootModel>()({
       return {
         ...state,
         closeTransactionScreen,
+      };
+    },
+    setAutocompleteTransaction(state, autocompleteTransaction: boolean): ConfigurationStateType {
+      return {
+        ...state,
+        autocompleteTransaction,
       };
     },
     setSelectedTheme(state, selectedTheme: string): ConfigurationStateType {

--- a/src/models/transactions.ts
+++ b/src/models/transactions.ts
@@ -354,8 +354,17 @@ export default createModel<RootModel>()({
 
       return response;
     },
+
     async deleteTransaction(id): Promise<AxiosResponse> {
       return dispatch.configuration.apiDelete({ url: `/api/v1/transactions/${id}` });
+    },
+
+    async getTransaction(id): Promise<TransactionType> {
+      const { data: transaction } = await dispatch.configuration.apiFetch({ url: `/api/v1/transactions/${id}` }) as {
+        data: TransactionType,
+      };
+
+      return transaction;
     },
   }),
 });


### PR DESCRIPTION
Hi folks! I know this is very out of the blue, but I've been using this app for a while and I would really love to have this feature implemented, as it greatly enhances *(at least my)* user experience.

*Note: this code is something I cobbled together in a couple of hours so it's obviously not something I expect to be merged as is.*

**Summary**
-   Added the option to automatically fill in the transaction information when selecting a transaction description from the autocomplete dropdown.
- Added a new setting under `Transaction Form` to control this new behavior

This is basically solution 4 from https://github.com/victorbalssa/abacus/issues/119 (I found this issue after I wrote the code 😅)

**Expected user flow**
- user clicks the `Plus` button to open the create new transaction form
- user fills in the transaction value
- user writes a few characters in the `Description` input field
- when selecting an already existing description from the autocomplete options => the remaining input fields should be filled in with values from the selected transaction

**Open questions**
- what should happen when the selected transaction is of a different type? (`withdraw` / `transfer` / `deposit`)
- what should happen when the selected transaction has multiple splits?
- what should happen when we're autocompleting inside a split transaction? (I think this MR kinda breaks things in this scenario by overwriting the source account)

Please let me know if this is something you're interested to merge.

Have an awesome day!
Robert.