### PR TITLE
Categories screen - Added transaction search by tapping on the item

### DIFF
--- a/src/components/Screens/HomeScreen.tsx
+++ b/src/components/Screens/HomeScreen.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { useFocusEffect, useScrollToTop } from '@react-navigation/native';
+import { CommonActions, useFocusEffect, useScrollToTop, useNavigation } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   RefreshControl,
@@ -170,6 +170,20 @@ function InsightCategories() {
   const insightCategories = useSelector((state: RootState) => state.categories.insightCategories);
   const loading = useSelector((state: RootState) => state.loading.effects.categories.getInsightCategories?.loading);
   const dispatch = useDispatch<RootDispatch>();
+  const navigation = useNavigation();
+  
+  const goToTransactions = async (id: string, trasactionSearch: string) => {
+    navigation.dispatch(
+      CommonActions.navigate(translate('navigation_transactions_tab'), {
+        screen: 'TransactionsScreen',
+        merge: true,
+        params: {
+          id,
+          trasactionSearch,
+        },
+      }),
+    );
+  };
 
   return (
     <AScrollView
@@ -188,6 +202,15 @@ function InsightCategories() {
         {translate('home_categories')}
       </AText>
       {insightCategories.map((category, index) => (
+        <TouchableOpacity
+          key={category.name}
+          onPress={() => {
+            if (category.name === 'total' || category.name === 'perday') return;
+            if (category.name === 'no-category') {
+              goToTransactions(category.id, 'has_any_category:false');
+            } else goToTransactions(category.id, `category_is:"${category.name}"`);
+          }}
+        >
         <AStack
           key={category.name}
           row
@@ -222,6 +245,7 @@ function InsightCategories() {
             </AText>
           </ASkeleton>
         </AStack>
+        </TouchableOpacity>
       ))}
       <AView style={{ height: 150 }} />
     </AScrollView>

--- a/src/components/Screens/TransactionsScreen.tsx
+++ b/src/components/Screens/TransactionsScreen.tsx
@@ -26,6 +26,7 @@ import {
   useNavigation,
 } from '@react-navigation/native';
 
+import { SearchBarCommands } from 'react-native-screens';
 import { GetTransactionsPayload, TransactionSplitType, TransactionType } from '../../models/transactions';
 import { RootDispatch, RootState } from '../../store';
 import translate from '../../i18n/locale';
@@ -327,6 +328,7 @@ export default function TransactionsScreen({ navigation, route }: ScreenType) {
     },
   } = useDispatch<RootDispatch>();
 
+  const searchBarRef = React.useRef<SearchBarCommands>();
   const onLoadMore = async () => {
     const payload: GetTransactionsPayload = {
       start,
@@ -358,6 +360,7 @@ export default function TransactionsScreen({ navigation, route }: ScreenType) {
   useLayoutEffect(() => {
     navigation.setOptions({
       headerSearchBarOptions: {
+        ref: searchBarRef,
         autoCapitalize: 'none',
         placeholder: translate('transaction_search_placeholder'),
         headerIconColor: colors.text,
@@ -370,6 +373,16 @@ export default function TransactionsScreen({ navigation, route }: ScreenType) {
         shouldShowHintSearchIcon: false,
       },
     });
+    //set search bar on first screen open
+    if (params?.trasactionSearch !== undefined) {
+      const p = { ...params };
+      setTimeout(() => {
+        setSearch(p?.trasactionSearch);
+        searchBarRef.current?.focus();
+        searchBarRef.current?.setText(p?.trasactionSearch);
+        searchBarRef.current?.blur();
+      }, 500);
+    }
   }, [navigation, search]);
 
   useFocusEffect(
@@ -381,6 +394,15 @@ export default function TransactionsScreen({ navigation, route }: ScreenType) {
           onLoad().catch();
           navigation.setParams({ forceRefresh: false });
         }
+      }
+
+      if (params?.trasactionSearch !== undefined) {
+        setSearch(params?.trasactionSearch);
+        searchBarRef.current?.focus();
+        searchBarRef.current?.setText(params?.trasactionSearch);
+        searchBarRef.current?.blur();
+        // disabled
+        params.trasactionSearch = undefined;
       }
 
       return () => {

--- a/src/types/screen.ts
+++ b/src/types/screen.ts
@@ -24,6 +24,7 @@ export interface ScreenType {
       forceRefresh?: boolean | undefined;
       noRedirect?: boolean;
       filterType?: string;
+      trasactionSearch?: string;
       selectFilter?: (filter: string) => void;
     }
   }


### PR DESCRIPTION
**Summary**

From the category screen, after touching the item, a search is performed for the category name and you are taken to the transaction list screen

It might solve the featured in #359 

![cat-search](https://github.com/user-attachments/assets/a3144cb3-cc98-4d36-80ac-3792c45500ab)
