### PR TITLE
use the correct endpoint starting from api version 6.3

### DIFF
--- a/src/i18n/locale/translations/en-US.ts
+++ b/src/i18n/locale/translations/en-US.ts
@@ -113,7 +113,7 @@ export default {
 
   // from 0.9.2
   assets_history_chart: 'Accounts chart',
-  balance_history_chart: 'Net Worth chart',
+  balance_history_chart: 'Balance chart',
   balance_history_chart_no_data: 'To access this graph, please update FireflyIII to the latest version.',
   account_not_included_in_net_worth: '* Account not included in Net Worth.',
 

--- a/src/models/firefly.ts
+++ b/src/models/firefly.ts
@@ -359,7 +359,8 @@ export default createModel<RootModel>()({
         }
 
         const accountIdsParam = accounts.map((a) => a.id).join('&filter[accounts][]=');
-        const { data: balances } = (await dispatch.configuration.apiFetch({ url: `/api/v2/chart/balance/balance?start=${start}&end=${end}&filter[accounts][]=${accountIdsParam}` })) as { data: BalanceType[] };
+        const endpoint = semver.gte(apiVersion, '6.3.0') ? '/api/v1/chart/balance/balance' : '/api/v2/chart/balance/balance';
+        const { data: balances } = (await dispatch.configuration.apiFetch({ url: `${endpoint}?start=${start}&end=${end}&filter[accounts][]=${accountIdsParam}` })) as { data: BalanceType[] };
 
         const earnedChartEntries = balances.filter((balance) => balance.currencyCode === currentCode && balance.label === 'earned')[0]?.entries;
 


### PR DESCRIPTION
fixes https://github.com/victorbalssa/abacus/issues/397

[starting from 6.3](https://github.com/firefly-iii/firefly-iii/blob/main/changelog.md?rgh-link-date=2025-09-30T12%3A05%3A58.000Z#630---2025-08-17), the API endpoints have moved from /v2 to /v1

I left the complete endpoints as strings so they are still easily searchable in the codebase.