### PR TITLE
select the correct date when deeplinking to transactions

### DIFF
--- a/src/components/Screens/HomeScreen.tsx
+++ b/src/components/Screens/HomeScreen.tsx
@@ -169,9 +169,10 @@ function InsightCategories() {
   const { colors } = useThemeColors();
   const insightCategories = useSelector((state: RootState) => state.categories.insightCategories);
   const loading = useSelector((state: RootState) => state.loading.effects.categories.getInsightCategories?.loading);
+  const startDate = useSelector((state: RootState) => state.firefly.rangeDetails.start);
   const dispatch = useDispatch<RootDispatch>();
   const navigation = useNavigation();
-  
+
   const goToTransactions = async (id: string, trasactionSearch: string) => {
     navigation.dispatch(
       CommonActions.navigate(translate('navigation_transactions_tab'), {
@@ -180,6 +181,7 @@ function InsightCategories() {
         params: {
           id,
           trasactionSearch,
+          startDate: new Date(`${startDate}T12:00:00`),
         },
       }),
     );

--- a/src/components/Screens/TransactionsScreen.tsx
+++ b/src/components/Screens/TransactionsScreen.tsx
@@ -405,6 +405,11 @@ export default function TransactionsScreen({ navigation, route }: ScreenType) {
         params.trasactionSearch = undefined;
       }
 
+      if (params?.startDate !== undefined) {
+        setStartDate(params.startDate);
+        params.startDate = undefined;
+      }
+
       return () => {
         isActive = false;
       };

--- a/src/types/screen.ts
+++ b/src/types/screen.ts
@@ -26,6 +26,7 @@ export interface ScreenType {
       noRedirect?: boolean;
       filterType?: string;
       trasactionSearch?: string;
+      startDate?: Date;
       selectFilter?: (filter: string) => void;
     }
   }


### PR DESCRIPTION
Once the transactions screen has its startDate state set, clicking through from dashboard categories to their transactions, the date is not updated correctly.

eg: 
- click on category to see its transactions
- change the date range to the previous month
- click on another category to see its transactions: incorrect date filter
