### PR TITLE
also allow switching between asset and all accounts in the history chart

### DIFF
--- a/src/components/Charts/AssetsHistoryChart.tsx
+++ b/src/components/Charts/AssetsHistoryChart.tsx
@@ -135,7 +135,10 @@ export default function AssetsHistoryChart() {
   const end = useSelector((state: RootState) => state.firefly.rangeDetails.end);
   const accountCharts = useSelector((state: RootState) => state.firefly?.accounts);
   const accounts = useSelector((state: RootState) => state.accounts.accounts);
-  const [hiddenAccounts, setHiddenAccounts] = useState<string[]>(accounts.filter((accountConfig) => !accountConfig.display).map((accountConfig) => accountConfig.attributes.name));
+  const [hiddenAccounts, setHiddenAccounts] = useState<string[]>([]);
+  useEffect(() => {
+    setHiddenAccounts(accounts.filter((accountConfig) => !accountConfig.display).map((accountConfig) => accountConfig.attributes.name));
+  }, [accounts]);
   const loading = useSelector((state: RootState) => state.loading.effects.firefly.getAccountChart?.loading);
   const currentCode = useSelector((state: RootState) => state.currencies.currentCode);
   const dispatch = useDispatch<RootDispatch>();

--- a/src/components/Charts/AssetsHistoryChart.tsx
+++ b/src/components/Charts/AssetsHistoryChart.tsx
@@ -311,7 +311,6 @@ export default function AssetsHistoryChart() {
     </ErrorBoundary>
   ), [
     loading,
-    accounts,
     accountCharts,
     colors,
     hiddenAccounts,

--- a/src/components/Charts/AssetsHistoryChart.tsx
+++ b/src/components/Charts/AssetsHistoryChart.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   VictoryAxis,
   VictoryChart,
@@ -11,10 +11,16 @@ import { AntDesign } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { useDispatch, useSelector } from 'react-redux';
 import * as Localization from 'expo-localization';
-import { Pressable, View, ScrollView } from 'react-native';
+import {
+  Pressable,
+  View,
+  ScrollView,
+  TouchableOpacity,
+  Switch,
+} from 'react-native';
 import {
   AStackFlex,
-  AText,
+  AText, AView,
 } from '../UI/ALibrary';
 
 import { RootDispatch, RootState } from '../../store';
@@ -22,6 +28,7 @@ import Loading from '../UI/Loading';
 import translate from '../../i18n/locale';
 import { useThemeColors } from '../../lib/common';
 import ErrorBoundary from '../UI/ErrorBoundary';
+import DisplayAllAccountsSwitch from '../UI/DisplayAllAccountsSwitch';
 
 function CursorPointer({ x, y, stroke }) {
   return (
@@ -126,10 +133,16 @@ export default function AssetsHistoryChart() {
   const { colors } = useThemeColors();
   const start = useSelector((state: RootState) => state.firefly.rangeDetails.start);
   const end = useSelector((state: RootState) => state.firefly.rangeDetails.end);
-  const accounts = useSelector((state: RootState) => state.firefly?.accounts);
+  const accountCharts = useSelector((state: RootState) => state.firefly?.accounts);
+  const accounts = useSelector((state: RootState) => state.accounts.accounts);
+  const [hiddenAccounts, setHiddenAccounts] = useState<string[]>(accounts.filter((accountConfig) => !accountConfig.display).map((accountConfig) => accountConfig.attributes.name));
   const loading = useSelector((state: RootState) => state.loading.effects.firefly.getAccountChart?.loading);
   const currentCode = useSelector((state: RootState) => state.currencies.currentCode);
   const dispatch = useDispatch<RootDispatch>();
+
+  useEffect(() => {
+    dispatch.firefly.getAccountChart();
+  }, [accounts]);
 
   const getTickValues = useCallback(() => {
     const dateArray = [];
@@ -158,7 +171,7 @@ export default function AssetsHistoryChart() {
         >
           <AStackFlex
             row
-            alignItems="baseline"
+            alignItems="center"
             justifyContent="space-between"
             style={{
               paddingHorizontal: 10,
@@ -170,14 +183,17 @@ export default function AssetsHistoryChart() {
               {' '}
               {currentCode}
             </AText>
-            <Pressable
-              onPress={() => {
-                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch();
-                dispatch.firefly.getAccountChart();
-              }}
-            >
-              <AntDesign name="reload1" size={24} color={colors.text} />
-            </Pressable>
+            <AStackFlex row justifyContent="flex-end" gap={10}>
+              <DisplayAllAccountsSwitch />
+              <Pressable
+                onPress={() => {
+                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch();
+                  dispatch.firefly.getAccountChart();
+                }}
+              >
+                <AntDesign name="reload1" size={24} color={colors.text} />
+              </Pressable>
+            </AStackFlex>
           </AStackFlex>
           <View style={{ height: 80 }} />
           {loading && (
@@ -206,8 +222,8 @@ export default function AssetsHistoryChart() {
                     x
                     y
                     activePoints
-                    maxY={maxBy(accounts, (c: { maxY: number }) => c.maxY)?.maxY || 0}
-                    minY={minBy(accounts, (c: { minY: number }) => c.minY)?.minY || 0}
+                    maxY={maxBy(accountCharts, (c: { maxY: number }) => c.maxY)?.maxY || 0}
+                    minY={minBy(accountCharts, (c: { minY: number }) => c.minY)?.minY || 0}
                     colors={colors}
                   />
               )}
@@ -242,7 +258,7 @@ export default function AssetsHistoryChart() {
                 },
               }}
             />
-            {accounts.map((chart) => chart.entries.length > 0 && (
+            {accountCharts.map((chart) => chart.entries.length > 0 && !hiddenAccounts.includes(chart.label) && (
               <VictoryLine
                 key={chart.label}
                 style={{
@@ -259,12 +275,42 @@ export default function AssetsHistoryChart() {
           </VictoryChart>
           )}
         </AStackFlex>
-        <View style={{ height: 200 }} />
+        <AStackFlex py={10} flexWrap="wrap" justifyContent="center" row>
+          {accountCharts.map((chart) => chart.entries.length > 0 && (
+            <TouchableOpacity
+              key={chart.label}
+              onPress={() => {
+                setHiddenAccounts(
+                  hiddenAccounts.includes(chart.label)
+                    ? hiddenAccounts.filter((hiddenLabel) => hiddenLabel !== chart.label)
+                    : [...hiddenAccounts, chart.label],
+                );
+              }}
+            >
+              <AView style={{
+                backgroundColor: hiddenAccounts.includes(chart.label) ? colors.backgroundColor : chart.color,
+                borderColor: hiddenAccounts.includes(chart.label) ? colors.backgroundColor : chart.color,
+                borderWidth: 2,
+                borderRadius: 10,
+                paddingHorizontal: 10,
+                height: 25,
+                margin: 2,
+              }}
+              >
+                <AText fontSize={15} color={hiddenAccounts.includes(chart.label) ? chart.color : colors.backgroundColor} bold>
+                  {chart.label}
+                </AText>
+              </AView>
+            </TouchableOpacity>
+          ))}
+        </AStackFlex>
       </ScrollView>
     </ErrorBoundary>
   ), [
     loading,
     accounts,
+    accountCharts,
     colors,
+    hiddenAccounts,
   ]);
 }

--- a/src/components/Screens/HomeScreen.tsx
+++ b/src/components/Screens/HomeScreen.tsx
@@ -6,7 +6,12 @@ import React, {
   useState,
 } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { CommonActions, useFocusEffect, useScrollToTop, useNavigation } from '@react-navigation/native';
+import {
+  CommonActions,
+  useFocusEffect,
+  useScrollToTop,
+  useNavigation,
+} from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   RefreshControl,
@@ -35,6 +40,7 @@ import {
   AProgressBar,
   ASkeleton, AStackFlex,
 } from '../UI/ALibrary';
+import DisplayAllAccountsSwitch from '../UI/DisplayAllAccountsSwitch';
 
 const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
 
@@ -46,11 +52,6 @@ function AssetsAccounts() {
   const dispatch = useDispatch<RootDispatch>();
   const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle || colors.brandStyleOrange);
 
-  const onSwitch = async (bool: boolean) => {
-    dispatch.configuration.setDisplayAllAccounts(bool);
-    dispatch.accounts.getAccounts();
-    return Promise.resolve();
-  };
   const [nameSortOrder, setNameSortOrder] = useState('asc');
   const [balanceSortOrder, setBalanceSortOrder] = useState('desc');
   const [lastPressed, setLastPressed] = useState(null);
@@ -95,11 +96,11 @@ function AssetsAccounts() {
       )}
     >
       <AView>
-        <AStack px={5} row justifyContent="space-between">
-          <AText fontSize={25} lineHeight={27} style={{ margin: 15 }} bold>
+        <AStack px={15} my={5} row justifyContent="space-between">
+          <AText fontSize={25} lineHeight={27} style={{ margin: 5 }} bold>
             {displayAllAccounts ? translate('home_all_accounts') : translate('home_accounts')}
           </AText>
-          <Switch style={{ marginHorizontal: 10 }} thumbColor="white" trackColor={{ false: '#767577', true: selectedBrandStyle }} onValueChange={onSwitch} value={displayAllAccounts} />
+          <DisplayAllAccountsSwitch />
         </AStack>
         <AStack px={5} row justifyContent="space-between">
           <View style={{ flex: 1, alignItems: 'flex-start', paddingLeft: '5%' }}>
@@ -171,7 +172,7 @@ function InsightCategories() {
   const loading = useSelector((state: RootState) => state.loading.effects.categories.getInsightCategories?.loading);
   const dispatch = useDispatch<RootDispatch>();
   const navigation = useNavigation();
-  
+
   const goToTransactions = async (id: string, trasactionSearch: string) => {
     navigation.dispatch(
       CommonActions.navigate(translate('navigation_transactions_tab'), {

--- a/src/components/UI/ALibrary/AStackFlex.tsx
+++ b/src/components/UI/ALibrary/AStackFlex.tsx
@@ -10,6 +10,7 @@ type AStackFlexType = {
   py?: number
   mx?: number
   my?: number
+  gap?: number
   row?: boolean
   flex?: number
   justifyContent?: 'center' | 'flex-start' | 'flex-end' | 'space-between' | 'space-around' | 'space-evenly'
@@ -25,6 +26,7 @@ export default function AStackFlex({
   py = 0,
   mx = 0,
   my = 0,
+  gap = 0,
   flex = 1,
   row = false,
   justifyContent = 'center',
@@ -40,6 +42,7 @@ export default function AStackFlex({
         flex,
         width: '100%',
         flexDirection: row ? 'row' : 'column',
+        gap,
         justifyContent,
         alignItems,
         backgroundColor,

--- a/src/components/UI/DisplayAllAccountsSwitch.tsx
+++ b/src/components/UI/DisplayAllAccountsSwitch.tsx
@@ -1,0 +1,26 @@
+import React, { useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Switch } from 'react-native';
+
+import { RootDispatch, RootState } from '../../store';
+import { useThemeColors } from '../../lib/common';
+
+export default function DisplayAllAccountsSwitch() {
+  const { colors } = useThemeColors();
+  const displayAllAccounts = useSelector((state: RootState) => state.configuration.displayAllAccounts);
+  const selectedBrandStyle = useSelector((state: RootState) => state.configuration.selectedBrandStyle || colors.brandStyleOrange);
+  const dispatch = useDispatch<RootDispatch>();
+
+  const onSwitch = async (bool: boolean) => {
+    dispatch.configuration.setDisplayAllAccounts(bool);
+    dispatch.accounts.getAccounts();
+    return Promise.resolve();
+  };
+
+  return useMemo(() => (
+    <Switch thumbColor="white" trackColor={{ false: '#767577', true: selectedBrandStyle }} onValueChange={onSwitch} value={displayAllAccounts} />
+  ), [
+    colors,
+    displayAllAccounts,
+  ]);
+}

--- a/src/components/UI/DisplayAllAccountsSwitch.tsx
+++ b/src/components/UI/DisplayAllAccountsSwitch.tsx
@@ -22,5 +22,6 @@ export default function DisplayAllAccountsSwitch() {
   ), [
     colors,
     displayAllAccounts,
+    selectedBrandStyle,
   ]);
 }

--- a/src/models/firefly.ts
+++ b/src/models/firefly.ts
@@ -285,11 +285,11 @@ export default createModel<RootModel>()({
           rangeDetails: { range, start, end },
         },
         currencies: { currentCode },
-        configuration: { selectedBrandStyle },
+        configuration: { selectedBrandStyle, displayAllAccounts },
       } = rootState;
 
       const { data: accounts } = (await dispatch.configuration.apiFetch({
-        url: `/api/v1/chart/account/overview?start=${start}&end=${end}`,
+        url: `/api/v1/chart/account/overview?start=${start}&end=${end}&preselected=${displayAllAccounts ? 'all' : ''}`,
       })) as { data: AssetAccountType[] };
       let colorIndex = 0;
 
@@ -337,7 +337,7 @@ export default createModel<RootModel>()({
           ).y;
         });
 
-      dispatch.firefly.setData({ accounts: accounts.filter((account) => account.currencyCode === currentCode).slice(0, 5) });
+      dispatch.firefly.setData({ accounts: accounts.filter((account) => account.currencyCode === currentCode) });
     },
 
     async getBalanceChart(_: void, rootState): Promise<void> {


### PR DESCRIPTION
Following the Asset/All accounts switch on the homepage, I've added the same ability to the accounts chart.

the switch itself is extracted in its own component so it can be reused, it toggles the same config value for both screens.

additionally the accounts are rendered below the chart and can be enabled/disabled on the fly. This makes the chart a little more usable when the scales of different accounts differ in orders of magintude.

Toggle is off: only default asset accounts available, only one of them is selected:
<img width="458" height="1065" alt="abacus-chart-1" src="https://github.com/user-attachments/assets/aebee487-c85f-4772-ab19-de839d79bbf8" />

Toggle is on: all accounts are available, 2 of them are selected:
<img width="458" height="1065" alt="abacus-chart-2" src="https://github.com/user-attachments/assets/e317ecfd-9b82-491a-a22e-7cb06b055c26" />

