### PR TITLE
improved assets homepage

### DIFF
--- a/src/components/Screens/HomeScreen.tsx
+++ b/src/components/Screens/HomeScreen.tsx
@@ -128,7 +128,7 @@ function AssetsAccounts() {
           const balance = parseFloat(account.attributes.currentBalance);
           const balanceDifference = parseFloat(account.attributes.balanceDifference);
           const balanceDifferencePercent = balance && balanceDifference
-            ? (Math.round((balanceDifference / balance) * 10000) / 100)
+            ? (Math.round((balanceDifference / Math.abs(balance)) * 10000) / 100)
             : 0;
           return (
             <AStackFlex
@@ -168,6 +168,7 @@ function AssetsAccounts() {
                         backgroundColor: balanceDifferencePercent < 0 && account.attributes.type !== 'liabilities' ? colors.red : colors.green,
                         borderRadius: 6,
                       }}
+                      color="white"
                     >
                       {balanceDifferencePercent}
                       %
@@ -185,19 +186,17 @@ function AssetsAccounts() {
                   >
                     {localNumberFormat(account.attributes.currencyCode, balance)}
                   </AText>
-                  <ASkeleton loading={loading}>
-                    {balanceDifferencePercent !== 0 && (
-                      <AText
-                        maxWidth={150}
-                        fontSize={12}
-                        numberOfLines={2}
-                        textAlign="right"
-                        color={balanceDifferencePercent < 0 && account.attributes.type !== 'liabilities' ? colors.brandStyleRed : colors.brandStyleGreen}
-                      >
-                        {localNumberFormat(account.attributes.currencyCode, balanceDifference)}
-                      </AText>
-                    )}
-                  </ASkeleton>
+                  {balanceDifferencePercent !== 0 && (
+                    <AText
+                      maxWidth={150}
+                      fontSize={12}
+                      numberOfLines={2}
+                      textAlign="right"
+                      color={balanceDifferencePercent < 0 && account.attributes.type !== 'liabilities' ? colors.brandDanger : colors.brandSuccess}
+                    >
+                      {localNumberFormat(account.attributes.currencyCode, balanceDifference)}
+                    </AText>
+                  )}
                 </ASkeleton>
               </AStackFlex>
             </AStackFlex>

--- a/src/components/Screens/HomeScreen.tsx
+++ b/src/components/Screens/HomeScreen.tsx
@@ -124,40 +124,85 @@ function AssetsAccounts() {
             </TouchableOpacity>
           </View>
         </AStack>
-        {sortedAccounts.map((account, index) => (
-          <AStack
-            key={account.id}
-            row
-            mx={15}
-            style={{
-              height: 45,
-              borderColor: colors.listBorderColor,
-              borderBottomWidth: index + 1 === accounts.length ? 0 : 0.5,
-            }}
-            justifyContent="space-between"
-          >
-            <AText
-              fontSize={14}
-              maxWidth="60%"
-              numberOfLines={1}
+        {sortedAccounts.map((account, index) => {
+          const balance = parseFloat(account.attributes.currentBalance);
+          const balanceDifference = parseFloat(account.attributes.balanceDifference);
+          const balanceDifferencePercent = balance && balanceDifference
+            ? (Math.round((balanceDifference / balance) * 10000) / 100)
+            : 0;
+          return (
+            <AStackFlex
+              key={account.id}
+              row
+              px={15}
+              py={10}
+              style={{
+                borderColor: colors.listBorderColor,
+                borderBottomWidth: index + 1 === accounts.length ? 0 : 0.5,
+              }}
             >
-              {account.attributes.name}
-              <AText fontSize={10}>
-                {account.attributes.includeNetWorth ? '' : '*'}
-              </AText>
-            </AText>
-
-            <ASkeleton loading={loading}>
-              <AText
-                maxWidth={150}
-                fontSize={14}
-                numberOfLines={1}
+              <AStackFlex
+                row
+                gap={10}
+                justifyContent="flex-start"
+                alignItems="center"
               >
-                {localNumberFormat(account.attributes.currencyCode, parseFloat(account.attributes.currentBalance))}
-              </AText>
-            </ASkeleton>
-          </AStack>
-        ))}
+                <AText
+                  fontSize={14}
+                  numberOfLines={1}
+                >
+                  {account.attributes.name}
+                  <AText fontSize={10}>
+                    {account.attributes.includeNetWorth ? '' : '*'}
+                  </AText>
+                </AText>
+
+                {balanceDifferencePercent !== 0 && (
+                  <ASkeleton loading={loading}>
+                    <AText
+                      fontSize={12}
+                      numberOfLines={2}
+                      textAlign="center"
+                      px={3}
+                      style={{
+                        backgroundColor: balanceDifferencePercent < 0 && account.attributes.type !== 'liabilities' ? colors.red : colors.green,
+                        borderRadius: 6,
+                      }}
+                    >
+                      {balanceDifferencePercent}
+                      %
+                    </AText>
+                  </ASkeleton>
+                )}
+              </AStackFlex>
+              <AStackFlex alignItems="flex-end" style={{ width: '100%' }}>
+                <ASkeleton loading={loading}>
+                  <AText
+                    maxWidth={150}
+                    fontSize={14}
+                    numberOfLines={2}
+                    textAlign="right"
+                  >
+                    {localNumberFormat(account.attributes.currencyCode, balance)}
+                  </AText>
+                  <ASkeleton loading={loading}>
+                    {balanceDifferencePercent !== 0 && (
+                      <AText
+                        maxWidth={150}
+                        fontSize={12}
+                        numberOfLines={2}
+                        textAlign="right"
+                        color={balanceDifferencePercent < 0 && account.attributes.type !== 'liabilities' ? colors.brandStyleRed : colors.brandStyleGreen}
+                      >
+                        {localNumberFormat(account.attributes.currencyCode, balanceDifference)}
+                      </AText>
+                    )}
+                  </ASkeleton>
+                </ASkeleton>
+              </AStackFlex>
+            </AStackFlex>
+          );
+        })}
         <AText fontSize={9} py={10} px={15}>
           {translate('account_not_included_in_net_worth')}
         </AText>

--- a/src/models/accounts.ts
+++ b/src/models/accounts.ts
@@ -6,6 +6,7 @@ export type AccountType = {
     accountNumber: string,
     accountRole: string,
     active: boolean,
+    balanceDifference: string,
     bic: null,
     createdAt: Date,
     creditCardType: string,
@@ -122,6 +123,7 @@ export default createModel<RootModel>()({
         },
         firefly: {
           rangeDetails: {
+            start,
             end,
           },
         },
@@ -135,7 +137,7 @@ export default createModel<RootModel>()({
           { data: accounts },
           { data: frontpageAccounts },
         ] = await Promise.all([
-          dispatch.configuration.apiFetch({ url: `/api/v1/currencies/${currentCode}/accounts?${displayAllAccounts ? '' : 'type=asset'}&date=${end}` }) as Promise<{ data: AccountType[] }>,
+          dispatch.configuration.apiFetch({ url: `/api/v1/currencies/${currentCode}/accounts?${displayAllAccounts ? '' : 'type=asset'}&start=${start}&end=${end}&date=${end}` }) as Promise<{ data: AccountType[] }>,
           dispatch.configuration.apiFetch({ url: '/api/v1/preferences/frontpageAccounts' }) as Promise<{ data: PreferenceType }>,
         ]);
         const filteredAccounts = accounts


### PR DESCRIPTION
Added balance difference and percentage to the assets homepage. Only renders when data is available, and difference for that period is <> 0

<img width="533" height="1073" alt="img" src="https://github.com/user-attachments/assets/53f14b18-0259-4183-bf72-7cd24ef07668" />

I did have to fix the assets endpoint in firefly, so be sure to use FF v6.4.2 to test. it is backward compatible and will simply not render the newly added content when it's not available.