### PR TITLE
correctly render the line markers on cursor when not all lines are active

### DIFF
--- a/src/components/Charts/AssetsHistoryChart.tsx
+++ b/src/components/Charts/AssetsHistoryChart.tsx
@@ -164,6 +164,8 @@ export default function AssetsHistoryChart() {
     return dateArray;
   }, [start, end]);
 
+  const activeCharts = accountCharts.filter((data) => data.entries.length > 0 && !hiddenAccounts.includes(data.label));
+
   return useMemo(() => (
     <ErrorBoundary>
       <ScrollView bounces={false}>
@@ -229,8 +231,8 @@ export default function AssetsHistoryChart() {
                     x
                     y
                     activePoints
-                    maxY={maxBy(accountCharts, (c: { maxY: number }) => c.maxY)?.maxY || 0}
-                    minY={minBy(accountCharts, (c: { minY: number }) => c.minY)?.minY || 0}
+                    maxY={maxBy(activeCharts, (c: { maxY: number }) => c.maxY)?.maxY || 0}
+                    minY={minBy(activeCharts, (c: { minY: number }) => c.minY)?.minY || 0}
                     colors={colors}
                   />
               )}
@@ -265,7 +267,7 @@ export default function AssetsHistoryChart() {
                 },
               }}
             />
-            {accountCharts.map((chart) => chart.entries.length > 0 && !hiddenAccounts.includes(chart.label) && (
+            {activeCharts.map((chart) => (
               <VictoryLine
                 key={chart.label}
                 style={{


### PR DESCRIPTION
When adding the option to deselect accounts in the asset chart in https://github.com/victorbalssa/abacus/pull/401, I did not take into account the custom cursor rendering. This did not follow the jumping of the Y scale, which is fixed by only passing the active lines to the min/max functions