### PR TITLE
fix #402 crash when initial state is from previous version

### DIFF
--- a/src/components/Screens/HomeScreen.tsx
+++ b/src/components/Screens/HomeScreen.tsx
@@ -277,7 +277,7 @@ function InsightCategories() {
                   </AText>
                 </ASkeleton>
               </AStack>
-              {!expensesOnly && category.name !== 'perday' && (
+              {!expensesOnly && category.name !== 'perday' && insightCategoriesTotal && (
                 <IncomeExpenseBar
                   income={category.income}
                   incomeTotal={category.name === 'total' ? insightCategoriesTotal.income - insightCategoriesTotal.expense : insightCategoriesTotal.income}

--- a/src/models/categories.ts
+++ b/src/models/categories.ts
@@ -21,30 +21,12 @@ export type InsightCategoryType = {
 
 export type CategoriesStateType = {
   insightCategories: InsightCategoryType[],
-  total: InsightCategoryType,
-  perDay: InsightCategoryType,
+  total?: InsightCategoryType,
+  perDay?: InsightCategoryType,
 }
 
 const INITIAL_STATE = {
   insightCategories: [],
-  total: {
-    name: 'total',
-    id: 'total',
-    currencyCode: '',
-    currencyId: '0',
-    income: 0,
-    expense: 0,
-    difference: 0,
-  },
-  perDay: {
-    name: 'perday',
-    id: 'perday',
-    currencyCode: '',
-    currencyId: '0',
-    income: 0,
-    expense: 0,
-    difference: 0,
-  },
 } as CategoriesStateType;
 
 const dateDiffInDays = (start, end) => {


### PR DESCRIPTION
During the implementation of the extended category overview in https://github.com/victorbalssa/abacus/pull/399 I added some additional state with coresponding initial state.
This initial state however, is not applied to installs that already have state. effectively making the newly added properties undefined.

This will cause a crash during calculation of the income/expense bar due to no total being present.