### PR TITLE
Add date section header and improve paddings

### DIFF
--- a/src/components/Screens/HomeScreen.tsx
+++ b/src/components/Screens/HomeScreen.tsx
@@ -140,9 +140,10 @@ function AssetsAccounts() {
             <AStackFlex
               key={account.id}
               row
-              px={15}
-              py={10}
+              mx={20}
               style={{
+                height: 45,
+                maxWidth: '90%',
                 borderColor: colors.listBorderColor,
                 borderBottomWidth: index + 1 === accounts.length ? 0 : 0.5,
               }}

--- a/src/components/Screens/HomeScreen.tsx
+++ b/src/components/Screens/HomeScreen.tsx
@@ -12,6 +12,7 @@ import {
   useScrollToTop,
   useNavigation,
 } from '@react-navigation/native';
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   RefreshControl,
@@ -44,10 +45,13 @@ import DisplayAllAccountsSwitch from '../UI/DisplayAllAccountsSwitch';
 import IncomeExpenseBar from '../UI/IncomeExpenseBar';
 import ErrorBoundary from '../UI/ErrorBoundary';
 
+const EXTRA_SCROLL_PADDING = 120;
+
 const AnimatedPagerView = Animated.createAnimatedComponent(PagerView);
 
 function AssetsAccounts() {
   const { colors } = useThemeColors();
+  const tabBarHeight = useBottomTabBarHeight();
   const accounts = useSelector((state: RootState) => state.accounts.accounts);
   const displayAllAccounts = useSelector((state: RootState) => state.configuration.displayAllAccounts);
   const loading = useSelector((state: RootState) => state.loading.effects.accounts.getAccounts?.loading);
@@ -87,6 +91,7 @@ function AssetsAccounts() {
   return (
     <AScrollView
       showsVerticalScrollIndicator={false}
+      style={{ paddingBottom: tabBarHeight + EXTRA_SCROLL_PADDING }}
       refreshControl={(
         <RefreshControl
           refreshing={false}
@@ -206,7 +211,6 @@ function AssetsAccounts() {
         <AText fontSize={9} py={10} px={15}>
           {translate('account_not_included_in_net_worth')}
         </AText>
-        <AView style={{ height: 150 }} />
       </AView>
     </AScrollView>
   );
@@ -214,6 +218,7 @@ function AssetsAccounts() {
 
 function InsightCategories() {
   const { colors } = useThemeColors();
+  const tabBarHeight = useBottomTabBarHeight();
   const insightCategories = useSelector((state: RootState) => state.categories.insightCategories);
   const insightCategoriesTotal = useSelector((state: RootState) => state.categories.total);
   const insightCategoriesPerDay = useSelector((state: RootState) => state.categories.perDay);
@@ -246,6 +251,7 @@ function InsightCategories() {
   return (
     <AScrollView
       showsVerticalScrollIndicator={false}
+      style={{ paddingBottom: tabBarHeight + EXTRA_SCROLL_PADDING }}
       refreshControl={(
         <RefreshControl
           refreshing={false}
@@ -337,13 +343,13 @@ function InsightCategories() {
           </TouchableOpacity>
         );
       })}
-      <AView style={{ height: 150 }} />
     </AScrollView>
   );
 }
 
 function InsightBudgets() {
   const { colors } = useThemeColors();
+  const tabBarHeight = useBottomTabBarHeight();
   const insightBudgets = useSelector((state: RootState) => state.budgets.budgets);
   const loading = useSelector((state: RootState) => state.loading.effects.budgets.getInsightBudgets?.loading);
   const dispatch = useDispatch<RootDispatch>();
@@ -351,6 +357,7 @@ function InsightBudgets() {
   return (
     <AScrollView
       showsVerticalScrollIndicator={false}
+      style={{ paddingBottom: tabBarHeight + EXTRA_SCROLL_PADDING }}
       refreshControl={(
         <RefreshControl
           refreshing={false}
@@ -412,7 +419,6 @@ function InsightBudgets() {
           />
         </AStack>
       ))}
-      <AView style={{ height: 150 }} />
     </AScrollView>
   );
 }
@@ -428,6 +434,7 @@ function formatDate(date) {
 
 function Bills() {
   const { colors } = useThemeColors();
+  const tabBarHeight = useBottomTabBarHeight();
   const bills = useSelector((state: RootState) => state.bills.bills);
   const loading = useSelector((state: RootState) => state.loading.effects.bills?.getBills?.loading);
   const dispatch = useDispatch<RootDispatch>();
@@ -439,6 +446,7 @@ function Bills() {
   return (
     <AScrollView
       showsVerticalScrollIndicator={false}
+      style={{ paddingBottom: tabBarHeight + EXTRA_SCROLL_PADDING }}
       refreshControl={(
         <RefreshControl
           refreshing={loading}
@@ -516,13 +524,13 @@ function Bills() {
           </AStack>
         );
       })}
-      <AView style={{ height: 150 }} />
     </AScrollView>
   );
 }
 
 function PiggyBanks() {
   const { colors } = useThemeColors();
+  const tabBarHeight = useBottomTabBarHeight();
   const piggyBanks = useSelector((state: RootState) => state.piggyBanks.piggyBanks);
   const loading = useSelector((state: RootState) => state.loading.effects.piggyBanks?.getPiggyBanks?.loading);
   const dispatch = useDispatch<RootDispatch>();
@@ -530,6 +538,7 @@ function PiggyBanks() {
   return (
     <AScrollView
       showsVerticalScrollIndicator={false}
+      style={{ paddingBottom: tabBarHeight + EXTRA_SCROLL_PADDING }}
       refreshControl={(
         <RefreshControl
           refreshing={false}
@@ -594,7 +603,6 @@ function PiggyBanks() {
           />
         </AStack>
       ))}
-      <AView style={{ height: 150 }} />
     </AScrollView>
   );
 }

--- a/src/components/Screens/TransactionsScreen.tsx
+++ b/src/components/Screens/TransactionsScreen.tsx
@@ -191,7 +191,11 @@ function RenderItem({ item }) {
             </AText>
 
             <AText fontSize={12} maxWidth={D_WIDTH - 175} numberOfLines={1}>
-              {`${moment(item.attributes.transactions[0].date).format('ll')} • ${item.attributes.transactions[0].categoryName || ''}`}
+              {`${moment(item.attributes.transactions[0].date).format('LT')}${
+                item.attributes.transactions[0].categoryName
+                  ? ` • ${item.attributes.transactions[0].categoryName}`
+                  : ''
+              }`}
             </AText>
             {item.attributes.transactions[0].tags.length > 0 && (
               <AStackFlex justifyContent="flex-start" alignItems="flex-start" row>
@@ -455,8 +459,30 @@ export default function TransactionsScreen({ navigation, route }: ScreenType) {
     setStartDate(new Date(`${defaultStart}T12:00:00`));
   };
 
+  const transactionSections = useMemo(
+    () => {
+      const byDay = new Map<string, TransactionType[]>();
+
+      transactions.forEach((t) => {
+        const date = t?.attributes?.transactions?.[0]?.date;
+        const dayKey = date ? moment(date).format('YYYY-MM-DD') : 'Invalid date';
+
+        const dayTransactions = byDay.get(dayKey);
+        if (dayTransactions) {
+          dayTransactions.push(t);
+        } else {
+          byDay.set(dayKey, [t]);
+        }
+      });
+
+      return Array.from(byDay.entries()).map(([title, data]) => ({ title, data }));
+    },
+    [transactions],
+  );
+
   return (
     <SwipeListView
+      useSectionList
       nestedScrollEnabled={false}
       contentInsetAdjustmentBehavior="automatic"
       refreshControl={(
@@ -490,8 +516,27 @@ export default function TransactionsScreen({ navigation, route }: ScreenType) {
       )}
       initialNumToRender={15}
       keyExtractor={(item: TransactionType) => item.id}
-      data={!loading ? transactions : []}
+      sections={!loading ? transactionSections : []}
       showsVerticalScrollIndicator
+      renderSectionHeader={({ section }) => {
+        const label = moment(section.title, 'YYYY-MM-DD', true).isValid()
+          ? moment(section.title, 'YYYY-MM-DD').format('LL')
+          : section.title;
+        return (
+          <AView
+            style={{
+              backgroundColor: colors.tileBackgroundColor,
+              paddingHorizontal: 10,
+              paddingTop: 12,
+              paddingBottom: 6,
+              borderTopWidth: 0.5,
+              borderColor: colors.listBorderColor,
+            }}
+          >
+            <AText bold>{label}</AText>
+          </AView>
+        );
+      }}
       renderItem={({ item }) => <RenderItem item={item} />}
       renderHiddenItem={(data, rowMap) => (
         <RenderHiddenItem


### PR DESCRIPTION
**Summary**
Hi, I have some small UI improvement for the app. I've only tested on iOS, though.

### Improve padding for asset accounts:

<img width="460" height="922" alt="Screenshot 2026-02-08 at 12 19 03" src="https://github.com/user-attachments/assets/7c9d8528-4214-4526-9a5f-128765105798" />

### Add padding so last item of of categories, subscription,... is visible:
<img width="457" height="913" alt="Screenshot 2026-02-08 at 12 19 15" src="https://github.com/user-attachments/assets/99ef6211-df46-4327-bdb9-42e5539de6e3" />

### Add section header (by date) for transactions:
<img width="447" height="922" alt="image" src="https://github.com/user-attachments/assets/3ff8c2d0-f4dc-475f-9c7d-c104f18cba95" />
