### PR TITLE
fix: set android network security config to trust user CAs

### DIFF
--- a/plugins/withAndroidManifest.js
+++ b/plugins/withAndroidManifest.js
@@ -1,23 +1,52 @@
-const { withAndroidManifest } = require('expo/config-plugins');
+const { withAndroidManifest, withDangerousMod } = require('expo/config-plugins');
+const { writeFileSync, mkdirSync } = require('fs');
+const { resolve } = require('path');
 
-function removeNetworkSecurityConfig(androidManifest) {
+function addNetworkSecurityConfig(androidManifest) {
   const newManifest = { ...androidManifest };
 
-  newManifest.manifest.application[0].$['android:networkSecurityConfig'] = undefined;
+  newManifest.manifest.application[0].$['android:networkSecurityConfig'] = '@xml/network_security_config';
   newManifest.manifest.application[0].$['android:usesCleartextTraffic'] = 'true';
 
   return newManifest;
 }
 
+function withNetworkSecurityConfigFile(config) {
+  return withDangerousMod(config, [
+    'android',
+    (c) => {
+      const xmlDir = resolve(c.modRequest.platformProjectRoot, 'app/src/main/res/xml');
+      mkdirSync(xmlDir, { recursive: true });
+      writeFileSync(
+        resolve(xmlDir, 'network_security_config.xml'),
+        `<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>
+`,
+      );
+      return c;
+    },
+  ]);
+}
+
 module.exports = function withAndroidPlugin(config) {
-  return withAndroidManifest(config, (configWithProps) => {
+  let newConfig = withAndroidManifest(config, (configWithProps) => {
     const mainApplication = configWithProps?.modResults;
 
     if (mainApplication) {
     // eslint-disable-next-line no-param-reassign
-      configWithProps.modResults = removeNetworkSecurityConfig(mainApplication);
+      configWithProps.modResults = addNetworkSecurityConfig(mainApplication);
     }
 
     return configWithProps;
   });
+
+  newConfig = withNetworkSecurityConfigFile(newConfig);
+  return newConfig;
 };


### PR DESCRIPTION
**Summary**

Android apps only trust system-preinstalled CAs by default (since API 24; Android 7). The previous plugin removed the network security config entirely, so user-installed certificates (self-signed, private/internal CAs) were rejected, causing "network error" when connecting to local Firefly III instances.

This adds a `network_security_config.xml` that explicitly trusts both system and user certificate stores, matching the behavior users expect from browsers and other apps like Waterfly-III.
Fixes #421 .

**Disclaimer**

This code change has been created with the help of AI.

**Verification**

I verified the changes against the official [Android docs](https://developer.android.com/privacy-and-security/security-config#base-config) as well as against [Waterfly-III's network security config](https://github.com/dreautall/waterfly-iii/blob/master/android/app/src/main/res/xml/network_security_config.xml).

Furthermore I did a quick sanity check by building the Android APK and verifying on my phone that it is indeed able to connect to the demo server as well as to my internal Firefly instance (using an internal CA from the Android user store).